### PR TITLE
Pad ragged paged attention if head_dim < 128

### DIFF
--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -1767,8 +1767,28 @@ def _do_tpu_ragged_paged_attention(
     soft_cap: float | None = None,
 ) -> NamedArray:
     # Usual shardmap dance
+    # Ensure last dimension (head_size) is a multiple of 128 for Pallas kernels
+    orig_head_size = q.axis_size("head_size")
+    padded_head_size = ((orig_head_size + 127) // 128) * 128
+
+    if padded_head_size != orig_head_size:
+        pad_amount = padded_head_size - orig_head_size
+        # Pad query on the head_size axis with zeros
+        q_padded = hax.concatenate(
+            "head_size",
+            [q, hax.zeros_like(q["head_size", hax.ds(0, pad_amount)])],
+        )
+        # Pad kv_pages on the head_size axis with zeros to match
+        kv_pages_padded = hax.concatenate(
+            "head_size",
+            [kv_pages, hax.zeros_like(kv_pages["head_size", hax.ds(0, pad_amount)])],
+        )
+    else:
+        q_padded = q
+        kv_pages_padded = kv_pages
+
     # The TPU kernel expects the second dimension of the query tensor to be the total number of query heads.
-    q_flat = q.flatten_axes(("kv_head", "q_heads_per_group"), "kv_head")
+    q_flat = q_padded.flatten_axes(("kv_head", "q_heads_per_group"), "kv_head")
     if num_seqs.ndim == 0:
         this_num_seqs = num_seqs.reshape((1,))
     else:
@@ -1784,7 +1804,7 @@ def _do_tpu_ragged_paged_attention(
         haliax.partitioning._get_mesh(),
         in_specs=(
             haliax.partitioning.pspec_for_axis(q_flat.axes),
-            haliax.partitioning.pspec_for_axis(kv_pages.axes),
+            haliax.partitioning.pspec_for_axis(kv_pages_padded.axes),
             haliax.partitioning.pspec_for_axis(kv_lens.axes),
             haliax.partitioning.pspec_for_axis(page_indices.axes),
             haliax.partitioning.pspec_for_axis(cu_q_lens.axes),
@@ -1801,7 +1821,7 @@ def _do_tpu_ragged_paged_attention(
         check_rep=False,
     )(
         q_flat.array,
-        kv_pages.array,
+        kv_pages_padded.array,
         kv_lens.array,
         page_indices.array,
         cu_q_lens.array,
@@ -1819,6 +1839,10 @@ def _do_tpu_ragged_paged_attention(
             q.resolve_axis("q_heads_per_group"),
         ),
     )
+
+    # If we padded head_size for the kernel, slice back to the original size
+    if padded_head_size != orig_head_size:
+        out = out["head_size", hax.ds(0, orig_head_size)]
 
     return out
 


### PR DESCRIPTION
Pallas kernels require the last dimension to be multiples of 128 [ref](https://arc.net/l/quote/ysqvyudd), so if the head dim is less than 128 as is the case for llama, we need to pad the last dimension to 128 and slice the output to use the kernel.