### PR TITLE
Enable documented steps_per_hf_export=-1 behavior

### DIFF
--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -201,7 +201,7 @@ def main(config: TrainLmConfig):
         )
         # trainer.add_hook(callbacks.GradWatchCallback(include_histograms=True), every=5)
 
-        if config.hf_save_path is not None:
+        if config.hf_save_path is not None and config.hf_save_steps is not None:
             # bit gross to reach this far into the config, but it's fine
             if config.trainer.checkpointer.append_run_id_to_base_path:
                 full_save_path = os.path.join(config.hf_save_path, trainer.run_id)


### PR DESCRIPTION
In Marin's `SimpleTrainConfig`, the documentation for `steps_per_hf_export: int | None = None` is "None means match steps_per_export, -1 disables" (https://github.com/marin-community/marin/blob/8825e9ec9c902a21fe4095efb4a3bcb09382a80b/experiments/simple_train_config.py#L61)

I am disabling exports for the speedrun template https://github.com/marin-community/marin/pull/1638 (as I don't think we should ask people to implement `HFCompatConfig` for a speedrun). However setting it to `-1` does not actually disable this. `default_train` would set `steps_per_export_hf` to None, which is passed to Levanter's trainer

```py
    if train_config.steps_per_hf_export is None:
        steps_per_export_hf = steps_per_export
    elif train_config.steps_per_hf_export == -1:
        steps_per_export_hf = None
    else:
        steps_per_export_hf = train_config.steps_per_hf_export
```

and we just get an error down the line

```
if force or info.step % hook.every == 0: 
            ~~~~~~~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for %: 'int' and 'NoneType'
```

This is a quick fix that prevents `save_hf_checkpoint_callback` from being added when `hf_save_steps` is None (though maybe we want to fix this in Marin).