### PR TITLE
Add compatibility helper for TPU pod type lookup

### DIFF
--- a/src/levanter/infra/ray_tpu.py
+++ b/src/levanter/infra/ray_tpu.py
@@ -41,6 +41,16 @@ from levanter.utils.ray_utils import ser_exc_info
 logger = logging.getLogger("ray")
 
 
+def _get_current_tpu_pod_type() -> str:
+    """Return the TPU pod type for the current node across Ray versions."""
+
+    if hasattr(TPUAcceleratorManager, "_get_current_node_tpu_pod_type"):
+        return TPUAcceleratorManager._get_current_node_tpu_pod_type()
+    if hasattr(TPUAcceleratorManager, "get_current_node_tpu_pod_type"):
+        return TPUAcceleratorManager.get_current_node_tpu_pod_type()
+    raise AttributeError("TPUAcceleratorManager is missing TPU pod type helpers")
+
+
 # CF https://gist.github.com/allenwang28/e3400b9e9212b50aa1cda55ebeccea60
 # CF: https://github.com/AI-Hypercomputer/ray-tpu/blob/main/src/ray_tpu.py
 
@@ -570,7 +580,7 @@ class SliceActor(ResourcePoolManager[TPUHostInfo]):
 
     def get_info(self) -> SliceInfo:
         pod_name = ray.util.accelerators.tpu.get_current_pod_name()
-        tpe = TPUAcceleratorManager._get_current_node_tpu_pod_type()
+        tpe = _get_current_tpu_pod_type()
 
         config = get_tpu_config(tpe)
 


### PR DESCRIPTION
## Summary
- add a TPU pod type helper that prefers Ray's new `_get_current_node_tpu_pod_type` and falls back to the legacy getter
- update the slice actor to use the compatibility helper when retrieving the TPU configuration

## Testing
- uv run pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68d8c9f54f8c8331b17cf93d73f53050