### PR TITLE
Add attention sink support to JAX Flash Attention

### DIFF
--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -86,6 +86,7 @@ def dot_product_attention(
     scaling_factor: float | None = None,
     inference: bool = True,
     prng: PRNGKeyArray | None = None,
+    attn_sink: Optional[NamedArray] = None,
 ):
     """
     This method is similar to [haliax.nn.attention.dot_product_attention][] but it can use different backends for
@@ -151,65 +152,127 @@ def dot_product_attention(
     if scaling_factor is None:
         scaling_factor = 1 / math.sqrt(query.resolve_axis(Key).size)
 
+    attention_out = None
+
     match attn_backend:
         case AttentionBackend.NVTE:
-            attention_out = _try_te_attention(
-                QPos,
-                KPos,
-                Key,
-                query,
-                key,
-                value,
-                mask,
-                bias,
-                dropout,
-                inference,
-                prng=prng,
-                attention_dtype=attention_dtype,
-                precision=precision,
-                flash_block_size=flash_block_size,
-                force_te=not was_default,
-                scaling_factor=scaling_factor,
-                logits_soft_cap=logits_soft_cap,
-            )
+            if attn_sink is None:
+                attention_out = _try_te_attention(
+                    QPos,
+                    KPos,
+                    Key,
+                    query,
+                    key,
+                    value,
+                    mask,
+                    bias,
+                    dropout,
+                    inference,
+                    prng=prng,
+                    attention_dtype=attention_dtype,
+                    precision=precision,
+                    flash_block_size=flash_block_size,
+                    force_te=not was_default,
+                    scaling_factor=scaling_factor,
+                    logits_soft_cap=logits_soft_cap,
+                )
+            else:
+                attention_out = None  # fall through to JAX
+
         case AttentionBackend.SPLASH:
-            attention_out = _try_tpu_splash_attention(
-                QPos,
-                KPos,
-                Key,
-                query,
-                key,
-                value,
-                mask,
-                bias,
-                dropout,
-                inference,
-                force_flash=not was_default,
-                prng=prng,
-                attention_dtype=attention_dtype,
-                precision=precision,
-                block_size=flash_block_size,
-                scaling_factor=scaling_factor,
-                logits_soft_cap=logits_soft_cap,
-            )
+            if attn_sink is None:
+                attention_out = _try_tpu_splash_attention(
+                    QPos,
+                    KPos,
+                    Key,
+                    query,
+                    key,
+                    value,
+                    mask,
+                    bias,
+                    dropout,
+                    inference,
+                    force_flash=not was_default,
+                    prng=prng,
+                    attention_dtype=attention_dtype,
+                    precision=precision,
+                    block_size=flash_block_size,
+                    scaling_factor=scaling_factor,
+                    logits_soft_cap=logits_soft_cap,
+                )
+            else:
+                try:
+                    attention_out = _tpu_splash_attention(  # type: ignore[call-arg]
+                        QPos,
+                        KPos,
+                        Key,
+                        query,
+                        key,
+                        value,
+                        mask=mask,
+                        bias=bias,
+                        inference=inference,
+                        block_size=flash_block_size,
+                        scaling_factor=scaling_factor,
+                        logits_soft_cap=logits_soft_cap,
+                        sinks=attn_sink,  # TODO: support after upgrade to JAX 0.7.2
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "TPU Splash w/ sinks unavailable (%s). Falling back to JAX Flash.",
+                        e,
+                    )
+                    attention_out = None
+
         case AttentionBackend.VANILLA:
-            attention_out = simple_attention_with_dropout(
-                QPos,
-                KPos,
-                Key,
-                query,
-                key,
-                value,
-                mask,
-                bias,
-                inference,
-                dropout,
-                attention_dtype,
-                precision,
-                prng=prng,
-                scaling_factor=scaling_factor,
-                logits_soft_cap=logits_soft_cap,
-            )
+            if attn_sink is None:
+                attention_out = simple_attention_with_dropout(
+                    QPos,
+                    KPos,
+                    Key,
+                    query,
+                    key,
+                    value,
+                    mask,
+                    bias,
+                    inference,
+                    dropout,
+                    attention_dtype,
+                    precision,
+                    prng=prng,
+                    scaling_factor=scaling_factor,
+                    logits_soft_cap=logits_soft_cap,
+                )
+            else:
+                key2, value2, mask2, bias2, KPosPlus = _materialize_sink_as_dummy_kv(
+                    QPos=QPos,
+                    KPos=KPos,
+                    Key=Key,
+                    query=query,
+                    key=key,
+                    value=value,
+                    attn_sink=attn_sink,
+                    mask=mask,
+                    bias=bias,
+                )
+                attention_out = simple_attention_with_dropout(
+                    QPos,
+                    KPosPlus,
+                    Key,
+                    query,
+                    key2,
+                    value2,
+                    mask2,
+                    bias2,
+                    inference,
+                    dropout,
+                    attention_dtype,
+                    precision,
+                    prng=prng,
+                    scaling_factor=scaling_factor,
+                    logits_soft_cap=logits_soft_cap,
+                )
+
         case _:
             attention_out = None
 
@@ -236,10 +299,12 @@ def dot_product_attention(
             precision=precision,
             scaling_factor=scaling_factor,
             logits_soft_cap=logits_soft_cap,
+            attn_sink=attn_sink,
         )
 
 
-def dot_product_attention_with_sink(
+def _materialize_sink_as_dummy_kv(
+    *,
     QPos: AxisSelector,
     KPos: AxisSelection,
     Key: AxisSelector,
@@ -247,21 +312,11 @@ def dot_product_attention_with_sink(
     key: NamedArray,
     value: NamedArray,
     attn_sink: NamedArray,
-    mask: Optional[Union["AttentionMask", NamedArray]] = None,
-    bias: Optional[NamedArray] = None,
-    attention_dtype: Optional[jnp.dtype] = None,
-    precision: PrecisionLike = None,
-    use_flash: Optional[bool] = None,
-    attn_backend: Optional[AttentionBackend] = None,
-    flash_block_size: Optional[int] = None,
-    dropout: float = 0.0,
-    *,
-    logits_soft_cap: float | None = None,
-    scaling_factor: float | None = None,
-    inference: bool = True,
-    prng: PRNGKeyArray | None = None,
+    mask: Optional[Union["AttentionMask", NamedArray]],
+    bias: Optional[NamedArray],
 ):
-    """Dot-product attention variant with a learned sink term per head.
+    """
+    Preprocess for dot-product attention variant with a learned sink term per head.
 
     The sink is implemented by appending a dummy key/value of zeros and
     inserting the sink logit via the bias term at the final key position.
@@ -302,25 +357,54 @@ def dot_product_attention_with_sink(
         zero_bias = hax.zeros(zero_bias_axes, dtype=sink_bias.dtype)
         bias = hax.concatenate(KPosPlus, [zero_bias, sink_bias])
 
+    return key, value, m, bias, KPosPlus
+
+
+def dot_product_attention_with_sink(
+    QPos: AxisSelector,
+    KPos: AxisSelection,
+    Key: AxisSelector,
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    attn_sink: NamedArray,
+    mask: Optional[Union["AttentionMask", NamedArray]] = None,
+    bias: Optional[NamedArray] = None,
+    attention_dtype: Optional[jnp.dtype] = None,
+    precision: PrecisionLike = None,
+    use_flash: Optional[bool] = None,
+    attn_backend: Optional[AttentionBackend] = None,
+    flash_block_size: Optional[int] = None,
+    dropout: float = 0.0,
+    *,
+    logits_soft_cap: float | None = None,
+    scaling_factor: float | None = None,
+    inference: bool = True,
+    prng: PRNGKeyArray | None = None,
+):
+    """
+    Compatibility wrapper: forwards directly to `dot_product_attention` with `attn_sink=...`.
+    """
     return dot_product_attention(
-        QPos,
-        KPosPlus,
-        Key,
-        query,
-        key,
-        value,
-        m,
-        bias,
-        attention_dtype,
-        precision,
-        use_flash,
-        attn_backend,
-        flash_block_size,
-        dropout,
+        QPos=QPos,
+        KPos=KPos,
+        Key=Key,
+        query=query,
+        key=key,
+        value=value,
+        mask=mask,
+        bias=bias,
+        attention_dtype=attention_dtype,
+        precision=precision,
+        use_flash=use_flash,
+        attn_backend=attn_backend,
+        flash_block_size=flash_block_size,
+        dropout=dropout,
         logits_soft_cap=logits_soft_cap,
         scaling_factor=scaling_factor,
         inference=inference,
         prng=prng,
+        attn_sink=attn_sink,
     )
 
 
@@ -441,7 +525,12 @@ def _try_te_attention(
             msg = "NVTE doesn't work with these arguments. Falling back to the reference implementation.\n"
             "Check nvte_get_fused_attn_backend for supported configurations:\n"
             "https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/common/fused_attn/fused_attn.cpp#L71"
-            if _dtype not in (jnp.float16, jnp.bfloat16, jnp.float8_e5m2, jnp.float8_e4m3fn):
+            if _dtype not in (
+                jnp.float16,
+                jnp.bfloat16,
+                jnp.float8_e5m2,
+                jnp.float8_e4m3fn,
+            ):
                 msg += f"In particular, NVTE doesn't support {_dtype} yet."
 
             if force_te:
@@ -722,7 +811,11 @@ def _unflatten_bshd(attn_output, q_class, v_class):
 
 
 def _materialize_segment_mask(
-    segment_ids: NamedArray | tuple[NamedArray, NamedArray], QPos, KPos, q_slice, k_slice
+    segment_ids: NamedArray | tuple[NamedArray, NamedArray],
+    QPos,
+    KPos,
+    q_slice,
+    k_slice,
 ) -> NamedArray:
     """
     Make a segment mask for attention. This is a mask that prevents attention between different segments.
@@ -791,7 +884,11 @@ class AttentionMask(eqx.Module):
     # cf https://github.com/google-research/t5x/blob/51a99bff8696c373cc03918707ada1e98cbca407/t5x/examples/decoder_only/layers.py#L978
 
     def materialize(
-        self, QPos: Axis, KPos: Axis, q_slice: Optional[haliax.dslice] = None, k_slice: Optional[haliax.dslice] = None
+        self,
+        QPos: Axis,
+        KPos: Axis,
+        q_slice: Optional[haliax.dslice] = None,
+        k_slice: Optional[haliax.dslice] = None,
     ) -> Optional[NamedArray]:
         """
         Materialize the mask as a NamedArray. This is useful for attention functions that don't support masks,
@@ -1320,7 +1417,8 @@ def _tpu_splash_attention(
         k = k.astype(attention_dtype)
         v = v.astype(attention_dtype)
         return jax.vmap(
-            lambda q, k, v, si: splash_kernel(q, k, v, segment_ids=si), in_axes=(0, 0, 0, segment_batch_axis)
+            lambda q, k, v, si: splash_kernel(q, k, v, segment_ids=si),
+            in_axes=(0, 0, 0, segment_batch_axis),
         )(q, k, v, segment_ids)
 
     attn_output = wrap_flash_attention(q_, k_, v_, segment_ids)
@@ -1476,13 +1574,25 @@ class Attention(eqx.Module):
             out_first=True,
         )
         k_proj = hnn.Linear.init(
-            In=config.Embed, Out=(config.KVHeads, config.HeadSize), key=k_k, use_bias=use_bias, out_first=True
+            In=config.Embed,
+            Out=(config.KVHeads, config.HeadSize),
+            key=k_k,
+            use_bias=use_bias,
+            out_first=True,
         )
         v_proj = hnn.Linear.init(
-            In=(config.Embed), Out=(config.KVHeads, config.HeadSize), key=k_v, use_bias=use_bias, out_first=True
+            In=(config.Embed),
+            Out=(config.KVHeads, config.HeadSize),
+            key=k_v,
+            use_bias=use_bias,
+            out_first=True,
         )
         o_proj = hnn.Linear.init(
-            In=(config.Heads, config.HeadSize), Out=config.Embed, key=k_o, use_bias=use_output_bias, out_first=True
+            In=(config.Heads, config.HeadSize),
+            Out=config.Embed,
+            key=k_o,
+            use_bias=use_output_bias,
+            out_first=True,
         )
 
         q_norm = None
@@ -1750,7 +1860,10 @@ def ragged_paged_attention(
             return out
         except Exception:  # pragma: no cover - fall back if kernel fails
             warnings.warn("TPU ragged paged attention failed. Falling back to reference implementation.")
-            logger.warning("Failed to use TPU ragged paged attention. Falling back to reference", exc_info=True)
+            logger.warning(
+                "Failed to use TPU ragged paged attention. Falling back to reference",
+                exc_info=True,
+            )
 
     return default_ragged_paged_attention(
         q,
@@ -1972,7 +2085,10 @@ def default_ragged_paged_attention(
             max_b = hax.full((Q_B, H, Q_H), -jnp.inf)
 
             o_b, sum_exp_b, max_b = jax.lax.fori_loop(
-                0, num_kv_blocks, _compute_attention_for_kv_block, (o_b, sum_exp_b, max_b)
+                0,
+                num_kv_blocks,
+                _compute_attention_for_kv_block,
+                (o_b, sum_exp_b, max_b),
             )
 
             # Normalize
@@ -2243,7 +2359,12 @@ class AttentionWithSink(Attention):
 
     @named_call
     def __call__(
-        self, x: NamedArray, mask: Optional[NamedArray | AttentionMask], *, key=None, pos_ids: NamedArray | None = None
+        self,
+        x: NamedArray,
+        mask: Optional[NamedArray | AttentionMask],
+        *,
+        key=None,
+        pos_ids: NamedArray | None = None,
     ) -> NamedArray:
         key_q, key_k, key_v, key_o = maybe_rng_split(key, 4)
 

--- a/src/levanter/models/flash_attention.py
+++ b/src/levanter/models/flash_attention.py
@@ -34,6 +34,7 @@ def flash_attention(
     v: hax.NamedArray,
     mask: Optional[AttentionMask | hax.NamedArray] = None,
     bias: Optional[hax.NamedArray] = None,
+    attn_sink: Optional[hax.NamedArray] = None,
     *,
     dropout: float = 0.0,
     inference: bool,
@@ -47,12 +48,11 @@ def flash_attention(
     """
     Crappy pure-jax Flash Attention impl, vaguely following the v2 paper.
 
-    Args:
-        Key: axis of key dim.
+    - If `block_size` doesn't divide Q/K, this falls back to the VANILLA path.
+      When `attn_sink` is provided, that fallback is forced to VANILLA to avoid recursion.
     """
     if not inference and dropout > 0 and key is None:
         raise ValueError("key must be provided for training")
-
     if dropout < 0 or dropout > 1:
         raise ValueError(f"invalid dropout {dropout}")
 
@@ -68,22 +68,50 @@ def flash_attention(
     KPos = k.resolve_axis(KPos)
 
     if QPos.size < block_size or KPos.size < block_size:
-        from levanter.layers.attention import simple_attention_with_dropout
+        if attn_sink is not None:
+            from levanter.layers.attention import dot_product_attention_with_sink
 
-        return simple_attention_with_dropout(
-            QPos,
-            KPos,
-            Key,
-            q,
-            k,
-            v,
-            mask=mask,
-            bias=bias,
-            dropout=dropout,
-            inference=inference,
-            prng=key,
-            logits_soft_cap=logits_soft_cap,
-        )
+            return dot_product_attention_with_sink(
+                QPos,
+                KPos,
+                Key,
+                q,
+                k,
+                v,
+                attn_sink,
+                mask=mask,
+                bias=bias,
+                attention_dtype=dtype,
+                precision=precision,
+                use_flash=False,  # force VANILLA
+                attn_backend=None,
+                flash_block_size=block_size,
+                dropout=dropout,
+                logits_soft_cap=logits_soft_cap,
+                scaling_factor=scaling_factor,
+                inference=inference,
+                prng=key,
+            )
+        else:
+            from levanter.layers.attention import simple_attention_with_dropout
+
+            return simple_attention_with_dropout(
+                QPos,
+                KPos,
+                Key,
+                q,
+                k,
+                v,
+                mask=mask,
+                bias=bias,
+                inference=inference,
+                dropout=dropout,
+                attention_dtype=dtype,
+                precision=precision,
+                prng=key,
+                scaling_factor=scaling_factor,
+                logits_soft_cap=logits_soft_cap,
+            )
 
     if scaling_factor is None:
         if Key.size == 0:
@@ -92,7 +120,7 @@ def flash_attention(
     q = q * scaling_factor
 
     return _flash_attention(
-        (q, k, v),
+        (q, k, v, attn_sink),
         QPos,
         KPos,
         Key,
@@ -109,7 +137,7 @@ def flash_attention(
 
 @equinox.filter_custom_vjp
 def _flash_attention(
-    qkv: Tuple[hax.NamedArray, hax.NamedArray, hax.NamedArray],
+    qkv_sink: Tuple[hax.NamedArray, hax.NamedArray, hax.NamedArray, Optional[hax.NamedArray]],
     QPos: hax.Axis,
     KPos: hax.Axis,
     Key: hax.Axis,
@@ -125,7 +153,7 @@ def _flash_attention(
 ) -> hax.NamedArray:
     return _flash_attention_forward(
         None,
-        qkv,
+        qkv_sink,
         QPos,
         KPos,
         Key,
@@ -143,7 +171,7 @@ def _flash_attention(
 @named_call
 def _flash_attention_forward(
     ignore,
-    qkv,
+    qkv_sink,
     QPos: hax.Axis,
     KPos: hax.Axis,
     Key: hax.AxisSelector,
@@ -158,7 +186,7 @@ def _flash_attention_forward(
     logits_soft_cap: Optional[float],
 ):
     del ignore
-    q, k, v = qkv
+    q, k, v, attn_sink = qkv_sink
     if QPos.size % block_size != 0:
         raise ValueError(f"q axis size {q.axis_size(QPos)} is not a multiple of {block_size}")
     if KPos.size % block_size != 0:
@@ -168,6 +196,7 @@ def _flash_attention_forward(
     Tr = QPos.size // block_size
     Tc = KPos.size // block_size
 
+    # Row axes: everything in q except (QPos, Key)
     q_batch_axes: Tuple[hax.Axis, ...] = hax.eliminate_axes(q.axes, (QPos, Key))
 
     # output variables: O is the attention output, ell is the per-position log normalizer
@@ -193,9 +222,23 @@ def _flash_attention_forward(
 
         # Step 2: init O_i = 0, sumexp_i = 0, max_i = -inf
         o_i = o[QPos, ds.block(i, block_size)]
+
         QPosBlock = QPos.resize(block_size)
-        sumexp_i = hax.zeros(q_batch_axes + (QPosBlock,), q.dtype)
-        max_i = hax.full(q_batch_axes + (QPosBlock,), -jnp.inf, q.dtype)
+        row_axes_block: Tuple[hax.Axis, ...] = q_batch_axes + (QPosBlock,)
+
+        sumexp_i = hax.zeros(row_axes_block, q.dtype)
+        max_i = hax.full(row_axes_block, -jnp.inf, q.dtype)
+
+        if attn_sink is not None:
+            sink_prefix = attn_sink
+            for ax in q_batch_axes:
+                if ax not in sink_prefix.axes:
+                    sink_prefix = sink_prefix.broadcast_axis(ax)
+            sink_block = sink_prefix.broadcast_axis(QPosBlock).astype(q.dtype)
+            # Ensure axis order matches row_axes_block
+            sink_block = sink_block.rearrange(row_axes_block)
+            max_i = sink_block
+            sumexp_i = hax.ones(row_axes_block, q.dtype)
 
         @named_call
         def do_qk_block(state):
@@ -230,18 +273,25 @@ def _flash_attention_forward(
                 attn_ij = hax.where(mask_ij, attn_ij, -1e10)
 
             if dropout > 0 and not inference:
-                attn_ij = hax.nn.dropout(attn_ij, dropout, inference=False, key=jax.random.fold_in(key, i * Tc + j))
+                attn_ij = hax.nn.dropout(
+                    attn_ij,
+                    dropout,
+                    inference=False,
+                    key=jax.random.fold_in(key, i * Tc + j),
+                )
 
             # Step 9: Compute m_i^j = max(m_i^{j-1}, rowmax(S_i^j)), P_i^j = exp(S_i^j - m_i^j),
             # ...    l_i^j = exp(m_i^{j-1} - m_i^j) + rowsum(P_i^j)
             max_i = hax.maximum(old_max_i, hax.max(attn_ij, axis=KPos.name))
             P_ij = hax.exp(attn_ij - max_i)
+            exp_diff = hax.exp(old_max_i - max_i).rearrange(row_axes_block)
 
-            exp_diff = hax.exp(old_max_i - max_i)
-            sumexp_i = exp_diff * sumexp_i + hax.sum(P_ij, axis=KPos.name)
+            rowsum = hax.sum(P_ij, axis=KPos.name).rearrange(row_axes_block)
+            sumexp_i = exp_diff * sumexp_i + rowsum
 
             # Step 10: Compute O_i = diag(exp(m_i^{j-1} - m_i^j) O_i + P_i^j V_j
-            o_i = exp_diff * o_i + hax.dot(P_ij, v_j, axis=KPos.name)
+            o_term = hax.dot(P_ij, v_j, axis=KPos.name).rearrange(o_i.axes)
+            o_i = exp_diff * o_i + o_term
 
             return (i, j + 1, o_i, q_i, sumexp_i, max_i)
 
@@ -249,7 +299,9 @@ def _flash_attention_forward(
         j_end = jnp.minimum(i + 1, Tc) if is_causal else Tc
 
         _, _, o_i, _, sumexp_i, max_i = jax.lax.while_loop(
-            lambda state: state[1] < j_end, do_qk_block, (i, 0, o_i, q_i, sumexp_i, max_i)
+            lambda state: state[1] < j_end,
+            do_qk_block,
+            (i, 0, o_i, q_i, sumexp_i, max_i),
         )
 
         # Step 12: compute O_i = diag(\ell_i^{Tc})^{-1} O_i^{Tc}
@@ -272,7 +324,7 @@ def _flash_attention_backward(
     residuals,
     grad_in: hax.NamedArray,
     ignore,
-    qkv,
+    qkv_sink,
     QPos: hax.Axis,
     KPos: hax.Axis,
     Key: hax.AxisSelector,
@@ -288,7 +340,7 @@ def _flash_attention_backward(
 ):
     del ignore
     O, L = residuals
-    q, k, v = qkv
+    q, k, v, attn_sink = qkv_sink
     dO = grad_in
 
     Tr = QPos.size // block_size
@@ -330,7 +382,12 @@ def _flash_attention_backward(
             attn_ij = hax.dot(q_i, k_j, precision=precision, axis=Key)
 
             if dropout > 0 and not inference:
-                attn_ij = hax.nn.dropout(attn_ij, dropout, inference=False, key=jax.random.fold_in(key, i * Tc + j))
+                attn_ij = hax.nn.dropout(
+                    attn_ij,
+                    dropout,
+                    inference=False,
+                    key=jax.random.fold_in(key, i * Tc + j),
+                )
 
             if bias is not None:
                 bias_ij = bias[QPos, ds.block(i, block_size), KPos, ds.block(j, block_size)]
@@ -346,7 +403,12 @@ def _flash_attention_backward(
             p_ij = hax.exp(attn_ij - L_i)
 
             if dropout > 0 and not inference:
-                p_ij = hax.nn.dropout(p_ij, dropout, inference=False, key=jax.random.fold_in(key, i * Tc + j))
+                p_ij = hax.nn.dropout(
+                    p_ij,
+                    dropout,
+                    inference=False,
+                    key=jax.random.fold_in(key, i * Tc + j),
+                )
 
             dP_ij = hax.dot(dO_i, v_j, axis=Key)
             dAttn_ij = p_ij * (dP_ij - D_i)
@@ -382,7 +444,23 @@ def _flash_attention_backward(
 
     # dQ, (dK, dV) = hax.scan(do_kv_block, Tc)(dQ, jnp.arange(Tc.size))
     j, dQ, dK, dV = jax.lax.while_loop(lambda state: state[0] < Tc, do_kv_block, (0, dQ, dK, dV))
-    return dQ.rearrange(q.axes), dK.rearrange(k.axes), dV.rearrange(v.axes)
+
+    if attn_sink is not None:
+        q_batch_axes: Tuple[hax.Axis, ...] = hax.eliminate_axes(q.axes, (QPos, Key))
+        sink_prefix = attn_sink
+        for ax in q_batch_axes:
+            if ax not in sink_prefix.axes:
+                sink_prefix = sink_prefix.broadcast_axis(ax)
+        sink_rows = sink_prefix.broadcast_axis(QPos).astype(L.dtype)
+
+        p_sink = hax.exp(sink_rows - L)
+        dsink_rows = -p_sink * D
+        reduce_axes = tuple(ax for ax in dsink_rows.axes if ax not in attn_sink.axes)
+        dsink = hax.sum(dsink_rows, reduce_axes).astype(attn_sink.dtype)
+    else:
+        dsink = None
+
+    return (dQ.rearrange(q.axes), dK.rearrange(k.axes), dV.rearrange(v.axes), dsink)
 
 
 _flash_attention.def_fwd(_flash_attention_forward)
@@ -395,7 +473,13 @@ def _infer_attention_output_block_shape(QPos, KPos, Key, q_i, k, v):
 
 
 def _materialize_mask_slice(mask, i, j, QPos, KPos, block_size):
-    return materialize_mask(mask, QPos, KPos, q_slice=hax.ds.block(i, block_size), k_slice=hax.ds.block(j, block_size))
+    return materialize_mask(
+        mask,
+        QPos,
+        KPos,
+        q_slice=hax.ds.block(i, block_size),
+        k_slice=hax.ds.block(j, block_size),
+    )
 
 
 def _strip_sizes(axes: AxisSpec) -> AxisSelection:

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -647,3 +647,120 @@ def test_attention_equivalence(
     o2 = sink_attention_ref_gpt_oss(q, k, v, sinks, sm_scale, sliding_window, start_q)
 
     torch.testing.assert_close(o1, o2)
+
+
+def sink_attention_jax_flash(
+    query,
+    key,
+    value,
+    sinks,
+    sm_scale: float = 0.125,
+    sliding_window: int | None = None,
+    start_q: int = 0,
+    *,
+    block_size: int = 64,
+):
+    import torch
+
+    batch_size, num_queries, num_key_value_heads, num_key_value_groups, head_dim = query.shape
+    _, num_keys, _, _ = key.shape
+
+    # Convert torch tensors to JAX NamedArrays
+    q_jax = jnp.array(query.to(torch.float32).cpu().numpy(), dtype=jnp.float32)
+    k_jax = jnp.array(key.to(torch.float32).cpu().numpy(), dtype=jnp.float32)
+    v_jax = jnp.array(value.to(torch.float32).cpu().numpy(), dtype=jnp.float32)
+    sink_jax = jnp.array(
+        sinks.view(num_key_value_heads, num_key_value_groups).to(torch.float32).cpu().numpy(),
+        dtype=jnp.float32,
+    )
+
+    Batch = Axis("batch", batch_size)
+    QPos = Axis("q_pos", num_queries)
+    KPos = Axis("k_pos", num_keys)
+    KVHead = Axis("kv_heads", num_key_value_heads)
+    KVGroup = Axis("kv_groups", num_key_value_groups)
+    D = Axis("head_dim", head_dim)
+
+    q = hax.named(q_jax, (Batch, QPos, KVHead, KVGroup, D))
+    k = hax.named(k_jax, (Batch, KPos, KVHead, D))
+    v = hax.named(v_jax, (Batch, KPos, KVHead, D))
+    sink = hax.named(sink_jax, (KVHead, KVGroup))
+
+    pos_queries = jnp.arange(num_queries, dtype=jnp.int32) + int(start_q)
+    pos_keys = jnp.arange(num_keys, dtype=jnp.int32)
+    mask_arr = pos_queries[:, None] >= pos_keys[None, :]
+    if sliding_window is not None:
+        mask_arr &= pos_queries[:, None] - sliding_window + 1 <= pos_keys[None, :]
+    mask = hax.named(mask_arr, (QPos, KPos))
+
+    out = dot_product_attention_with_sink(
+        QPos,
+        KPos,
+        D,
+        q,
+        k,
+        v,
+        sink,
+        mask=mask,
+        scaling_factor=sm_scale,
+        attn_backend=AttentionBackend.JAX_FLASH,
+        flash_block_size=block_size,
+        inference=True,
+    )
+
+    out_np = np.asarray(out.array, dtype=np.float32)
+    out_torch = torch.from_numpy(out_np).to(query.device)
+    out_torch = out_torch.view(batch_size, num_queries, num_key_value_heads, num_key_value_groups, head_dim)
+    return out_torch.reshape(batch_size, num_queries, -1).bfloat16()
+
+
+@skip_if_no_torch
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("num_queries", [128])
+@pytest.mark.parametrize("num_keys", [128])
+@pytest.mark.parametrize("num_key_value_heads", [8])
+@pytest.mark.parametrize("num_key_value_groups", [8])
+@pytest.mark.parametrize("head_dim", [64])
+@pytest.mark.parametrize("sm_scale", [0.125])
+@pytest.mark.parametrize("sliding_window", [None, 64])
+@pytest.mark.parametrize("start_q", [0, 5])
+@pytest.mark.parametrize("block_size", [64])
+def test_attention_equivalence_jax_flash(
+    batch_size,
+    num_queries,
+    num_keys,
+    num_key_value_heads,
+    num_key_value_groups,
+    head_dim,
+    sm_scale,
+    sliding_window,
+    start_q,
+    block_size,
+):
+    """Make sure the JAX backend is tested"""
+    import torch
+
+    if num_queries > num_keys:
+        pytest.skip("too many queries")
+    if (num_queries % block_size) != 0 or (num_keys % block_size) != 0:
+        pytest.skip("block size must divide sequence lengths for JAX Flash path")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    q = torch.randn(
+        batch_size,
+        num_queries,
+        num_key_value_heads,
+        num_key_value_groups,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(batch_size, num_keys, num_key_value_heads, head_dim, device=device, dtype=torch.bfloat16)
+    v = torch.randn(batch_size, num_keys, num_key_value_heads, head_dim, device=device, dtype=torch.bfloat16)
+    sinks = torch.randn(num_key_value_heads * num_key_value_groups, device=device, dtype=torch.bfloat16)
+
+    o1 = sink_attention_jax_flash(q, k, v, sinks, sm_scale, sliding_window, start_q, block_size=block_size)
+    o2 = sink_attention_ref_gpt_oss(q, k, v, sinks, sm_scale, sliding_window, start_q)
+
+    torch.testing.assert_close(o1, o2)


### PR DESCRIPTION
The JAX attention backend now natively supports attention sinks, and tests are added to actually test the JAX backend.

Completes one path of https://github.com/marin-community/levanter/issues/1215