### PR TITLE
Flash Gated Delta Rule kernels in Pallas

### DIFF
--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -33,6 +33,7 @@ import dataclasses
 import functools
 import os
 from typing import Optional, Tuple
+import contextlib
 
 import equinox as eqx
 import jax
@@ -63,6 +64,12 @@ def _should_interpret_pallas() -> bool:
     except RuntimeError:
         platform = "cpu"
     return platform == "cpu"
+
+
+@contextlib.contextmanager
+def _fp32_mm():
+    with jax.default_matmul_precision("float32"):
+        yield
 
 
 # ---------- small utilities ----------
@@ -232,6 +239,64 @@ def _causal_depthwise_conv1d_update(
 # ---------- Fused Gated RMSNorm ----------
 
 
+@jax.custom_vjp
+def _rmsnorm_gated_flash(x_2d: jnp.ndarray, gate_2d: jnp.ndarray, weight: jnp.ndarray, eps: float) -> jnp.ndarray:
+    """Forward: call the Pallas fused kernel (fallback to reference).
+    Backward: analytic grads in pure JAX (no Pallas autodiff)."""
+    try:
+        return _fused_rmsnorm_gated_pallas(x_2d, gate_2d, weight, eps)
+    except Exception:
+        return _rmsnorm_gated_reference(x_2d, gate_2d, weight, eps)
+
+
+def _rmsnorm_gated_flash_fwd(x_2d, gate_2d, weight, eps):
+    y = _rmsnorm_gated_flash(x_2d, gate_2d, weight, eps)
+    # Keep inputs as residuals; recompute inv etc. in bwd
+    return y, (x_2d, gate_2d, weight, jnp.asarray(eps, dtype=jnp.float32))
+
+
+def _rmsnorm_gated_flash_bwd(res, dY):
+    x_2d, gate_2d, weight, eps32 = res
+    # Promote to fp32
+    x = x_2d.astype(jnp.float32)
+    gate = gate_2d.astype(jnp.float32)
+    w = weight.astype(jnp.float32)
+    dY = dY.astype(jnp.float32)
+
+    # Row-wise RMSNorm stats
+    # inv = 1 / sqrt(mean(x^2) + eps)
+    D = x.shape[-1]
+    inv = lax.rsqrt(jnp.mean(x * x, axis=-1, keepdims=True) + eps32)  # [N,1]
+    y_no_gate = (x * inv) * w  # [N,D]
+
+    # SiLU and derivative
+    sigma = jax.nn.sigmoid(gate)  # [N,D]
+    silu = gate * sigma
+    silu_prime = sigma * (1.0 + gate * (1.0 - sigma))  # [N,D]
+
+    # Chain rule
+    dy = dY * silu  # [N,D]
+    # y_no_gate = (x*inv) * w = u * w, with u = x*inv
+    du = dy * w  # [N,D]
+
+    # dweight: sum over rows of dy * (x * inv)
+    dW = jnp.sum(dy * (x * inv), axis=0)  # [D]
+
+    # dx: u = x*inv  with inv = (mean(x^2)+eps)^(-1/2)
+    # dL/dx = inv * du + (-inv^3 / D) * x * dot(du, x), where dot is along last dim
+    dot = jnp.sum(du * x, axis=-1, keepdims=True)  # [N,1]
+    dx = inv * du + (-(inv**3) / float(D)) * x * dot  # [N,D]
+
+    # dgate: elementwise (no reduction)
+    dGate = dY * y_no_gate * silu_prime  # [N,D]
+
+    # Cast back to input dtypes
+    return (dx.astype(x_2d.dtype), dGate.astype(gate_2d.dtype), dW.astype(weight.dtype), None)  # no grad for eps
+
+
+_rmsnorm_gated_flash.defvjp(_rmsnorm_gated_flash_fwd, _rmsnorm_gated_flash_bwd)
+
+
 class FusedRMSNormGated(eqx.Module):
     """RMSNorm(x) * SiLU(gate) using an optional fused Pallas kernel."""
 
@@ -260,10 +325,9 @@ class FusedRMSNormGated(eqx.Module):
 
         if self.use_flash:
             try:
-                out_arr = _fused_rmsnorm_gated_pallas(x_arr, gate_arr, weight_arr, self.eps)
+                out_arr = _rmsnorm_gated_flash(x_arr, gate_arr, weight_arr, self.eps)
             except Exception:
-                if self.use_flash:
-                    raise
+                # If Pallas fails at runtime, fall back to reference (grad still correct via custom VJP bwd)
                 out_arr = _rmsnorm_gated_reference(x_arr, gate_arr, weight_arr, self.eps)
         else:
             out_arr = _rmsnorm_gated_reference(x_arr, gate_arr, weight_arr, self.eps)
@@ -1364,21 +1428,19 @@ def _gdn_chunk_fwd_kernel_fused(
     yv_tile = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
 
     def fs_v(i, Y):
-        # rhs = β_i * v_i
-        rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]  # (BV,)
+        rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]
 
-        # accumulate sum_{j<i} A0[i,j] * exp(g_i - g_j) * U_j
         def acc_v(j, acc):
             aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-            decay_ij = jnp.exp(g_cum[i] - g_cum[j])  # in (0, 1]
-            uj = lax.dynamic_slice(Y, (j, 0), (1, BV))[0]  # (BV,)
+            decay_ij = jnp.exp(g_cum[i] - g_cum[j])
+            uj = lax.dynamic_slice(Y, (j, 0), (1, BV))[0]
             return acc + (aij * decay_ij) * uj
 
         contrib = lax.fori_loop(0, i, acc_v, jnp.zeros((BV,), dtype=jnp.float32))
         yi = rhs_i + contrib
         return lax.dynamic_update_slice(Y, yi[None, :], (i, 0))
 
-    yv_tile = lax.fori_loop(0, chunk_len, fs_v, yv_tile)
+    yv_tile = lax.fori_loop(0, active, fs_v, yv_tile)
 
     # ===========================
     # yk_tile via forward-sub:   (I - Ā) W = e^{g} ⊙ (βK)
@@ -1386,26 +1448,24 @@ def _gdn_chunk_fwd_kernel_fused(
     yk_tile = jnp.zeros((chunk_len, BK), dtype=jnp.float32)
 
     def fs_k(kb, Y):
-        # do a small W recurrence for BK columns in this tile
         k0 = kb * BK
-        # Prepare RHS tile once for all rows: e^{g} * β * K_tile
-        k_t = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))  # (C, BK)
+        k_t = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
         rhs_tile = (eg[:, None] * (b_c[:, None] * k_t)).astype(jnp.float32)
 
         def fs_row(i, Ycur):
-            rhs_i = lax.dynamic_slice(rhs_tile, (i, 0), (1, BK))[0]  # (BK,)
+            rhs_i = lax.dynamic_slice(rhs_tile, (i, 0), (1, BK))[0]
 
             def acc_k(j, acc):
                 aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-                decay_ij = jnp.exp(g_cum[i] - g_cum[j])  # in (0, 1]
-                wj = lax.dynamic_slice(Ycur, (j, 0), (1, BK))[0]  # (BK,)
+                decay_ij = jnp.exp(g_cum[i] - g_cum[j])
+                wj = lax.dynamic_slice(Ycur, (j, 0), (1, BK))[0]
                 return acc + (aij * decay_ij) * wj
 
             contrib = lax.fori_loop(0, i, acc_k, jnp.zeros((BK,), dtype=jnp.float32))
             yi = rhs_i + contrib
             return lax.dynamic_update_slice(Ycur, yi[None, :], (i, 0))
 
-        return lax.fori_loop(0, chunk_len, fs_row, Y)
+        return lax.fori_loop(0, active, fs_row, Y)
 
     yk_tile = lax.fori_loop(0, n_kb, fs_k, yk_tile)
 
@@ -1607,17 +1667,18 @@ def _chunk_gated_delta_rule_flash_fused(
         S_in, out_buf = carry
         ci_ary = jnp.asarray([ci], dtype=jnp.int32)
 
-        out_tiles, s_tiles = pl.pallas_call(
-            kernel,
-            out_shape=(
-                jax.ShapeDtypeStruct((NH, n_vtiles, C, BV), value.dtype),
-                jax.ShapeDtypeStruct((NH, n_vtiles, K, BV), jnp.float32),
-            ),
-            grid=(NH, n_vtiles),
-            in_specs=in_specs,
-            out_specs=out_specs,
-            interpret=_should_interpret_pallas(),
-        )(q_flat, k_flat, v_flat, g_flat, b_flat, S_in, ci_ary, lengths_flat)
+        with _fp32_mm():
+            out_tiles, s_tiles = pl.pallas_call(
+                kernel,
+                out_shape=(
+                    jax.ShapeDtypeStruct((NH, n_vtiles, C, BV), value.dtype),
+                    jax.ShapeDtypeStruct((NH, n_vtiles, K, BV), jnp.float32),
+                ),
+                grid=(NH, n_vtiles),
+                in_specs=in_specs,
+                out_specs=out_specs,
+                interpret=_should_interpret_pallas(),
+            )(q_flat, k_flat, v_flat, g_flat, b_flat, S_in, ci_ary, lengths_flat)
 
         out_chunk = out_tiles.reshape(NH, C, n_vtiles * BV)[:, :, :V_pad]
         s_chunk = s_tiles.reshape(NH, K, n_vtiles * BV)[:, :, :V_pad]
@@ -1634,6 +1695,222 @@ def _chunk_gated_delta_rule_flash_fused(
     out_named = out_bHLv if head_first else jnp.transpose(out_bHLv, (0, 2, 1, 3))
     S_ret = None if not output_final_state else S_final[:, :, :V].reshape(B, H, K, V)
     return out_named, S_ret
+
+
+# ---------------------------------------------------------------------------
+# Rematerialized backward for the flash chunk kernel (custom VJP wrapper)
+# ---------------------------------------------------------------------------
+
+# We wrap a *pure arrays* front-end around `_chunk_gated_delta_rule_flash_fused`
+# and give it a custom VJP whose backward recomputes the reference forward and
+# uses JAX's VJP to obtain gradients. This avoids saving large per-token
+# intermediates from the flash forward (T, W/U, etc.).
+#
+# Notes:
+# - All non-differentiable flags are marked static via `nondiff_argnums`.
+# - We ignore d(final_state) in backward (it's not used in training prefill);
+#   if you want gradients wrt initial_state in the future, wire a second VJP
+#   with a reverse scan over the chunk bridge.
+#
+
+
+@functools.partial(
+    jax.custom_vjp,
+    nondiff_argnums=(
+        8,  # chunk_size (int)
+        9,  # output_final_state (bool)
+        10,  # use_qk_l2norm_in_kernel (bool)
+        11,  # head_first (bool)
+        12,  # use_varlen (bool)
+    ),
+)
+def _chunk_gated_delta_rule_flash_call(
+    q_arr: jnp.ndarray,  # [B, L, H, K] if head_first=False; else [B, H, L, K]
+    k_arr: jnp.ndarray,  # same layout as q_arr
+    v_arr: jnp.ndarray,  # [B, L, H, V] or [B, H, L, V]
+    g_arr: jnp.ndarray,  # [B, L, H]     or [B, H, L]
+    beta_arr: jnp.ndarray,  # [B, L, H]     or [B, H, L]
+    lengths: Optional[jnp.ndarray],  # shape [B, H] or [B*H], or None ⇒ full length
+    offsets: Optional[jnp.ndarray],  # unused here; keep for API compatibility
+    initial_state: Optional[jnp.ndarray],  # normally None for train/prefill
+    chunk_size: int,
+    output_final_state: bool,
+    use_qk_l2norm_in_kernel: bool,
+    head_first: bool,
+    use_varlen: bool,
+):
+    # Forward simply defers to the fused Pallas implementation.
+    with _fp32_mm():
+        out_arr, final_state = _chunk_gated_delta_rule_flash_fused(
+            q_arr,
+            k_arr,
+            v_arr,
+            g_arr,
+            beta_arr,
+            chunk_size=chunk_size,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            head_first=head_first,
+            lengths=lengths,
+            offsets=offsets,
+            use_varlen=use_varlen,
+        )
+    return (out_arr, final_state)
+
+
+def _chunk_gated_delta_rule_flash_call_fwd(
+    q_arr,
+    k_arr,
+    v_arr,
+    g_arr,
+    beta_arr,
+    lengths,
+    offsets,
+    initial_state,
+    chunk_size,
+    output_final_state,
+    use_qk_l2norm_in_kernel,
+    head_first,
+    use_varlen,
+):
+    out_arr, final_state = _chunk_gated_delta_rule_flash_fused(
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        chunk_size=chunk_size,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        head_first=head_first,
+        lengths=lengths,
+        offsets=offsets,
+        use_varlen=use_varlen,
+    )
+
+    # IMPORTANT: store initial_state in residuals so bwd can compute dS0
+    res = (
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        lengths,  # may be None
+        head_first,  # layout flag
+        initial_state,  # may be None; needed for dS0
+    )
+    return (out_arr, final_state), res
+
+
+def _chunk_gated_delta_rule_flash_call_bwd(
+    chunk_size,
+    output_final_state,
+    use_qk_l2norm_in_kernel,
+    head_first,
+    use_varlen,  # 5 static args
+    res,
+    cotangents,
+):
+    # Unpack residuals
+    q_arr, k_arr, v_arr, g_arr, beta_arr, lengths, head_first_res, initial_state_arr = res
+    d_out_arr, d_final_state = cotangents  # we ignore d(final_state) in this pass
+
+    # Build NamedArrays for the reference VJP (canonical [B, L, H, *] layout)
+    if not head_first:
+        B, L, H, K = q_arr.shape
+        V = v_arr.shape[-1]
+        q_named = hax.named(q_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)))
+        k_named = hax.named(k_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)))
+        v_named = hax.named(v_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V)))
+        g_named = hax.named(g_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H)))
+        b_named = hax.named(beta_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H)))
+        d_out_named = hax.named(
+            d_out_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V))
+        )
+    else:
+        B, H, L, K = q_arr.shape
+        V = v_arr.shape[-1]
+        q_named = hax.named(
+            jnp.transpose(q_arr, (0, 2, 1, 3)),
+            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)),
+        )
+        k_named = hax.named(
+            jnp.transpose(k_arr, (0, 2, 1, 3)),
+            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)),
+        )
+        v_named = hax.named(
+            jnp.transpose(v_arr, (0, 2, 1, 3)),
+            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V)),
+        )
+        g_named = hax.named(jnp.transpose(g_arr, (0, 2, 1)), (Axis("batch", B), Axis("position", L), Axis("heads", H)))
+        b_named = hax.named(
+            jnp.transpose(beta_arr, (0, 2, 1)), (Axis("batch", B), Axis("position", L), Axis("heads", H))
+        )
+        d_out_named = hax.named(
+            jnp.transpose(d_out_arr, (0, 2, 1, 3)),
+            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V)),
+        )
+
+    # Initial state for the reference VJP (NamedArray on [B, H, K, V])
+    if initial_state_arr is None:
+        S0_arr = jnp.zeros((B, H, K, V), dtype=jnp.float32)
+    else:
+        S0_arr = initial_state_arr
+        # Pad/trim last axis not needed here; flash forward already padded V internally
+
+    S0_named = hax.named(S0_arr, (Axis("batch", B), Axis("heads", H), Axis("k_head_dim", K), Axis("v_head_dim", V)))
+
+    # Reference forward that returns only the chunk output (for VJP)
+    def _ref_f(qN, kN, vN, gN, bN, S0N):
+        yN, _ = _chunk_gated_delta_rule_reference(
+            qN,
+            kN,
+            vN,
+            gN,
+            bN,
+            chunk_size=chunk_size,
+            initial_state=S0N.array,  # IMPORTANT: pass S0 into the reference
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+        return yN
+
+    # Rematerialized VJP
+    _, pullback = jax.vjp(_ref_f, q_named, k_named, v_named, g_named, b_named, S0_named)
+    dQ, dK, dV, dG, dB, dS0 = pullback(d_out_named)
+
+    # Pack grads back to arrays matching the *primal* argument order
+    if not head_first:
+        dq = dQ.array
+        dk = dK.array
+        dv = dV.array
+        dg = dG.array
+        db = dB.array
+        dS0_arr = dS0.array  # [B, H, K, V]
+    else:
+        dq = jnp.transpose(dQ.array, (0, 2, 1, 3))
+        dk = jnp.transpose(dK.array, (0, 2, 1, 3))
+        dv = jnp.transpose(dV.array, (0, 2, 1, 3))
+        dg = jnp.transpose(dG.array, (0, 2, 1))
+        db = jnp.transpose(dB.array, (0, 2, 1))
+        dS0_arr = dS0.array  # S0 is [B,H,K,V] regardless
+
+    d_lengths = None
+    d_offsets = None
+    d_initial_state = dS0_arr
+
+    # Return grads for the *first 8* (differentiable) args of the primal:
+    # (q, k, v, g, beta, lengths, offsets, initial_state)
+    return (dq, dk, dv, dg, db, d_lengths, d_offsets, d_initial_state)
+
+
+# Tie the custom VJP to the forward/backward defs
+_chunk_gated_delta_rule_flash_call.defvjp(
+    _chunk_gated_delta_rule_flash_call_fwd,
+    _chunk_gated_delta_rule_flash_call_bwd,
+)
 
 
 def _wrap_chunk_out_as_named(out_arr, query, value, *, head_first: bool):
@@ -1673,19 +1950,19 @@ def chunk_gated_delta_rule(
 ) -> tuple[NamedArray, Optional[jnp.ndarray]]:
     if use_flash:
         try:
-            out_arr, fin = _chunk_gated_delta_rule_flash_fused(
+            out_arr, fin = _chunk_gated_delta_rule_flash_call(
                 query.array,
                 key.array,
                 value.array,
                 g.array,
                 beta.array,
-                chunk_size=chunk_size,
+                lengths=lengths,
+                offsets=offsets,
                 initial_state=initial_state,
+                chunk_size=chunk_size,
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
                 head_first=head_first,
-                lengths=lengths,
-                offsets=offsets,
                 use_varlen=use_varlen,
             )
             out_named = _wrap_chunk_out_as_named(out_arr, query, value, head_first=head_first)

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -1226,170 +1226,282 @@ def _chunk_gated_delta_rule_reference(
     return (out_final, S) if output_final_state else (out_final, None)
 
 
-def _ceil_div(x: int, y: int) -> int:
-    return (x + y - 1) // y
+def _build_T_from_kbeta(
+    k_c: jnp.ndarray,  # (C, K)  L2-normalized K for this chunk (fp32)
+    b_c: jnp.ndarray,  # (C,)    beta for this chunk (fp32)
+    g_cum: jnp.ndarray,  # (C,)    cumulative g within chunk (fp32)
+    *,
+    K: int,
+    BK: int,
+) -> jnp.ndarray:
+    """Build T = (I - A)^(-1) for a chunk with only static-shape slices (Pallas-safe)."""
+    C = k_c.shape[0]
+
+    # --- A[i,j] = -exp(g_i - g_j) * <kβ_i, k_j> for j < i; else 0 ---
+    def dot_full(i, j):
+        # <kβ_i, k_j> = b_i * <k_i, k_j>, reduced over K in BK tiles
+        def body(kb2, s):
+            kk = kb2 * BK
+            ki = lax.dynamic_slice(k_c, (i, kk), (1, BK))[0]  # (BK,)
+            kj = lax.dynamic_slice(k_c, (j, kk), (1, BK))[0]  # (BK,)
+            return s + jnp.sum((b_c[i] * ki) * kj, dtype=jnp.float32)
+
+        n_kb2 = (K + BK - 1) // BK
+        return lax.fori_loop(0, n_kb2, body, jnp.array(0.0, jnp.float32))
+
+    # Fill A one row at a time, writing only j<i
+    A = jnp.zeros((C, C), dtype=jnp.float32)
+
+    def fill_A_row(i, A_cur):
+        row = jnp.zeros((C,), dtype=jnp.float32)
+
+        def inner(j, r):
+            coeff = -jnp.exp(g_cum[i] - g_cum[j]) * dot_full(i, j)
+            return r.at[j].set(coeff)
+
+        row = lax.fori_loop(0, i, inner, row)  # j = 0..i-1
+        return lax.dynamic_update_slice(A_cur, row[None, :], (i, 0))
+
+    A = lax.fori_loop(1, C, fill_A_row, A)
+
+    # --- Forward substitution to get T - I, row by row ---
+    # Invariant: after processing i-1, TL[:i,:] holds (T - I) rows 0..i-1.
+    TL = A
+
+    def fwd_sub_row(i, TL_cur):
+        row = lax.dynamic_slice(TL_cur, (i, 0), (1, C))[0]  # A[i,:]
+        # zero out entries >= i so 'row @ TL_cur' only uses j < i automatically
+        ar = lax.broadcasted_iota(jnp.int32, (C,), 0)
+        m1 = (ar < jnp.int32(i)).astype(jnp.float32)
+        row_pref = row * m1  # (C,)
+        incr = row_pref @ TL_cur  # (C,) == Σ_{j<i} row[j] * TL[j,:]
+        row_new = row + incr * m1  # keep strictly-lower structure
+        return lax.dynamic_update_slice(TL_cur, row_new[None, :], (i, 0))
+
+    TL = lax.fori_loop(1, C, fwd_sub_row, TL)
+    T = TL + jnp.eye(C, dtype=jnp.float32)
+    return T
 
 
-@dataclass(frozen=True)
-class _Tiles:
-    BK: int = 64
-    BV: int = 64
+# --- per-chunk UT to form yk = T @ (βK ⊙ exp(g_cum)) ---
+def _gdn_chunk_prepare_yk_kernel(
+    k_ref,  # [NH, T_pad, K]
+    g_ref,  # [NH, T_pad]
+    beta_ref,  # [NH, T_pad]
+    yk_ref,  # [NH, Nc, C, K]  (output)
+    *,
+    T_pad: int,
+    K: int,
+    chunk_len: int,
+    BK: int,
+):
+    nhc = pl.program_id(0)
+    kt = pl.program_id(1)
+    Nc = T_pad // chunk_len
+    nh = nhc // Nc
+    ci = nhc - nh * Nc
+    k0 = kt * BK  # K-tile start (BK already clamped ≤ K)
+
+    c0 = ci * chunk_len
+    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C,K)
+    g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)  # (C,)
+    b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)  # (C,)
+
+    g_cum = jnp.cumsum(g_c, axis=0).astype(jnp.float32)
+    Tmat = _build_T_from_kbeta(k_c, b_c, g_cum, K=K, BK=BK)  # (C,C)
+
+    # rhs for YK: (β K) ⊙ exp(g_cum) row-wise
+    rhs_blk = jnp.exp(g_cum)[:, None] * (k_c * b_c[:, None])  # (C,K)
+    rhs_tile = lax.dynamic_slice(rhs_blk, (0, k0), (chunk_len, BK))  # (C,BK)
+
+    # YK_tile = T @ rhs_tile  → (C, BK)
+    # Implement as explicit sum to maintain identical accumulation order across dtypes
+    def col_body(c, acc):
+        col = lax.dynamic_slice(rhs_tile, (0, c), (chunk_len, 1))[:, 0]  # (C,)
+        y = Tmat @ col  # (C,)
+        return acc.at[:, c].set(y)
+
+    yk_tile = jnp.zeros((chunk_len, BK), dtype=jnp.float32)
+    yk_tile = lax.fori_loop(0, BK, col_body, yk_tile)
+
+    yk_ref[dslice(nhc, 1), dslice(ci, 1), dslice(0, chunk_len), dslice(k0, BK)] = yk_tile[None, None, :, :]
 
 
-def _pick_tiles(dk: int, dv: int) -> _Tiles:
-    bk = 64 if dk >= 128 else 32
-    bv = 64 if dv >= 128 else 32
-    return _Tiles(BK=bk, BV=bv)
+def _prepare_yk_pallas(k_flat, g_flat, b_flat, *, T_pad, K, chunk_len, BK):
+    NH = k_flat.shape[0]
+    Nc = T_pad // chunk_len
+    out_yk = jnp.zeros((NH, Nc, chunk_len, K), dtype=jnp.float32)
+
+    grid = (NH * Nc, (K + BK - 1) // BK)
+    (out_yk,) = pl.pallas_call(
+        functools.partial(
+            _gdn_chunk_prepare_yk_kernel,
+            T_pad=T_pad,
+            K=K,
+            chunk_len=int(chunk_len),
+            BK=int(BK),
+        ),
+        out_shape=(jax.ShapeDtypeStruct(out_yk.shape, out_yk.dtype),),
+        grid=grid,
+        in_specs=(
+            pl.BlockSpec((1, T_pad, K), lambda nhc, kt: (nhc // Nc, 0, 0)),  # k
+            pl.BlockSpec((1, T_pad), lambda nhc, kt: (nhc // Nc, 0)),  # g
+            pl.BlockSpec((1, T_pad), lambda nhc, kt: (nhc // Nc, 0)),  # β
+        ),
+        out_specs=(pl.BlockSpec((1, 1, chunk_len, BK), lambda nhc, kt: (nhc // Nc, nhc % Nc, 0, kt * BK)),),
+        interpret=_should_interpret_pallas(),
+    )(k_flat, g_flat, b_flat)
+    return out_yk
 
 
-def _pad_L_axis(x: jnp.ndarray, width: int) -> jnp.ndarray:
-    if width <= 0:
-        return x
-    if x.ndim == 2:  # [NH, L]
-        return jnp.pad(x, ((0, 0), (0, width)))
-    elif x.ndim == 3:  # [NH, L, D]
-        return jnp.pad(x, ((0, 0), (0, width), (0, 0)))
-    elif x.ndim == 4:  # [B, H, L, D]
-        return jnp.pad(x, ((0, 0), (0, 0), (0, width), (0, 0)))
-    else:
-        raise ValueError(f"Unexpected rank for length-padding: {x.ndim}")
-
-
-def _gdn_chunk_fwd_kernel(
-    q_ref,  # [NH, T_pad, K]
+def _gdn_chunk_prepare_yv_kernel(
     k_ref,  # [NH, T_pad, K]
     v_ref,  # [NH, T_pad, V]
     g_ref,  # [NH, T_pad]
     beta_ref,  # [NH, T_pad]
-    init_ref,  # [NH, K, V]
-    lengths_ref,  # [NH]  (real lengths, but we rely on zero padding)
-    out_ref,  # [NH, T_pad, V]
-    final_ref,  # [NH, K, V]
+    yv_ref,  # [NH, Nc, C, V]
     *,
     T_pad: int,
     K: int,
     V: int,
     chunk_len: int,
-    head_first: bool,
-    store_final_state: bool,
-    use_qk_l2norm_in_kernel: bool,
-    BK: int,
-    BV: int,
+    BK: int,  # used to scan K for dot_ij
+    BV: int,  # V tile
 ):
-    nh = pl.program_id(axis=0)
+    nhc = pl.program_id(0)
+    vt = pl.program_id(1)
+    Nc = T_pad // chunk_len
+    nh = nhc // Nc
+    ci = nhc - nh * Nc
+    v0 = vt * BV  # V-tile start (BV already clamped ≤ V)
 
-    # Per-(seq,head) views (depend on refs → no capture)
-    q_view = q_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, K)][0]
-    k_view = k_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, K)][0]
-    v_view = v_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, V)][0]
-    g_view = g_ref[dslice(nh, 1), dslice(0, T_pad)][0]
-    b_view = beta_ref[dslice(nh, 1), dslice(0, T_pad)][0]
+    c0 = ci * chunk_len
+    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C,K)
+    v_c = v_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, V)][0].astype(jnp.float32)  # (C,V)
+    g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
+    b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
 
-    # FP32 state S
-    S = init_ref[dslice(nh, 1), dslice(0, K), dslice(0, V)][0].astype(jnp.float32)
+    g_cum = jnp.cumsum(g_c, axis=0).astype(jnp.float32)
+    Tmat = _build_T_from_kbeta(k_c, b_c, g_cum, K=K, BK=BK)  # (C,C)
 
-    # “zero” scratch derived from inputs (no captured zero)
-    out_tile = v_view * (g_view[:, None] - g_view[:, None])  # [T_pad, V], all zeros
+    rhs_blk = v_c * b_c[:, None]  # (C,V)
+    rhs_tile = lax.dynamic_slice(rhs_blk, (0, v0), (chunk_len, BV))  # (C,BV)
 
-    # 1/sqrt(K) passed as kwarg would be nice, but this constant is tiny and stable
-    # Make it an input-like traced scalar: multiply sum-by-sum to get 1 then divide by sqrt(K)
-    # However, to keep things simple and JAX-friendly, do this:
-    scale = jnp.asarray(1.0 / jnp.sqrt(K), dtype=jnp.float32)
+    def col_body(c, acc):
+        col = lax.dynamic_slice(rhs_tile, (0, c), (chunk_len, 1))[:, 0]  # (C,)
+        y = Tmat @ col  # (C,)
+        return acc.at[:, c].set(y)
 
-    nchunks_max = T_pad // chunk_len
+    yv_tile = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
+    yv_tile = lax.fori_loop(0, BV, col_body, yv_tile)
 
-    def chunk_body(c_idx, carry):
-        S_carry, out_tile_carry = carry
-        # dynamic indices only: derive zero from c_start
-        c_start = c_idx * chunk_len
-        zero_col_dyn = c_start - c_start
-
-        # Fixed-size chunk slices
-        q_c = lax.dynamic_slice(q_view, (c_start, zero_col_dyn), (chunk_len, K)).astype(jnp.float32)
-        k_c = lax.dynamic_slice(k_view, (c_start, zero_col_dyn), (chunk_len, K)).astype(jnp.float32)
-        v_c = lax.dynamic_slice(v_view, (c_start, zero_col_dyn), (chunk_len, V)).astype(jnp.float32)
-        g_c = lax.dynamic_slice(g_view, (c_start,), (chunk_len,)).astype(jnp.float32)
-        b_c = lax.dynamic_slice(b_view, (c_start,), (chunk_len,)).astype(jnp.float32)
-
-        # Optional L2-norm + scale
-        if use_qk_l2norm_in_kernel:
-            qn = jnp.sqrt(jnp.sum(q_c * q_c, axis=1, keepdims=True) + 1e-6)
-            kn = jnp.sqrt(jnp.sum(k_c * k_c, axis=1, keepdims=True) + 1e-6)
-            q_c = q_c / jnp.where(qn > 0, qn, 1.0)
-            k_c = k_c / jnp.where(kn > 0, kn, 1.0)
-        q_c = q_c * scale
-
-        # Chunkwise cumsum/exp
-        g_cum = jnp.cumsum(g_c, axis=0)  # (C,)
-        eg_cum = jnp.exp(g_cum)  # (C,)
-
-        v_beta = v_c * b_c[:, None]  # (C,V)
-        k_beta = k_c * b_c[:, None]  # (C,K)
-
-        # UT buffers as "zeros" from inputs
-        yv = v_c * (g_c[:, None] - g_c[:, None])  # (C,V)
-        yk = k_c * (g_c[:, None] - g_c[:, None])  # (C,K)
-
-        def ut_row_update(i, carry_ut):
-            yv_cur, yk_cur = carry_ut
-
-            # accumulate over j < i
-            def acc_j(j, acc):
-                acc_v, acc_k = acc
-                dot_ij = jnp.dot(k_beta[i], k_c[j])
-                coeff = -dot_ij * jnp.exp(g_cum[i] - g_cum[j])
-                acc_v = acc_v + coeff * yv_cur[j]
-                acc_k = acc_k + coeff * yk_cur[j]
-                return (acc_v, acc_k)
-
-            zero_v = v_c[0] * (g_c[0] - g_c[0])
-            zero_k = k_c[0] * (g_c[0] - g_c[0])
-            acc_v, acc_k = lax.fori_loop(0, i, acc_j, (zero_v, zero_k))
-            yv_cur = yv_cur.at[i].set(v_beta[i] + acc_v)
-            yk_cur = yk_cur.at[i].set(k_beta[i] * eg_cum[i] + acc_k)
-            return (yv_cur, yk_cur)
-
-        # device loop over rows
-        yv, yk = lax.fori_loop(0, chunk_len, ut_row_update, (yv, yk))
-
-        # ---- bridge with cross-chunk S and compute outputs ----
-        qexp = q_c * eg_cum[:, None]
-        v_prime = yk @ S_carry
-        inter = qexp @ S_carry
-
-        # lower-triangular (incl. diagonal) attention-like term (vectorized)
-        attn_raw = (q_c @ k_c.T) * jnp.exp(g_cum[:, None] - g_cum[None, :])
-        idx_i = lax.broadcasted_iota(jnp.int32, (chunk_len, chunk_len), 0)
-        idx_j = lax.broadcasted_iota(jnp.int32, (chunk_len, chunk_len), 1)
-        zero_scalar = jnp.sum(g_c[:1] - g_c[:1])
-        attn = jnp.where(idx_i >= idx_j, attn_raw, zero_scalar)
-        v_new = yv - v_prime
-        out_chunk = inter + attn @ v_new
-
-        # write chunk result
-        out_tile_next = lax.dynamic_update_slice(
-            out_tile_carry, out_chunk.astype(out_ref.dtype), (c_start, zero_col_dyn)
-        )
-
-        # ---- Update S ----
-        g_tail = jnp.sum(g_c, axis=0)
-        decay_tail = jnp.exp(g_tail)
-        S_carry = S_carry * decay_tail
-        dw_full = jnp.exp(g_tail - g_cum)
-        k_scaled = k_c * dw_full[:, None]
-        S_carry = S_carry + k_scaled.T @ v_new
-
-        return (S_carry, out_tile_next)
-
-    S, out_tile = lax.fori_loop(0, nchunks_max, chunk_body, (S, out_tile))
-
-    # final writes (add singleton to match NDIndexer slice)
-    out_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, V)] = out_tile[None, :, :]
-    if store_final_state:
-        final_ref[dslice(nh, 1), dslice(0, K), dslice(0, V)] = S.astype(final_ref.dtype)[None, :, :]
+    yv_ref[dslice(nhc, 1), dslice(ci, 1), dslice(0, chunk_len), dslice(v0, BV)] = yv_tile[None, None, :, :]
 
 
-def _chunk_gated_delta_rule_flash_tiled(
+def _prepare_yv_pallas(k_flat, v_flat, g_flat, b_flat, *, T_pad, K, V, chunk_len, BK, BV):
+    NH = k_flat.shape[0]
+    Nc = T_pad // chunk_len
+    out_yv = jnp.zeros((NH, Nc, chunk_len, V), dtype=jnp.float32)
+
+    grid = (NH * Nc, (V + BV - 1) // BV)
+    (out_yv,) = pl.pallas_call(
+        functools.partial(
+            _gdn_chunk_prepare_yv_kernel,
+            T_pad=T_pad,
+            K=K,
+            V=V,
+            chunk_len=int(chunk_len),
+            BK=int(BK),
+            BV=int(BV),
+        ),
+        out_shape=(jax.ShapeDtypeStruct(out_yv.shape, out_yv.dtype),),
+        grid=grid,
+        in_specs=(
+            pl.BlockSpec((1, T_pad, K), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0, 0)),  # k
+            pl.BlockSpec((1, T_pad, V), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0, 0)),  # v
+            pl.BlockSpec((1, T_pad), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0)),  # g
+            pl.BlockSpec((1, T_pad), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0)),  # β
+        ),
+        out_specs=(
+            pl.BlockSpec(
+                (1, 1, chunk_len, BV),
+                lambda nhc, vt: (nhc // (T_pad // chunk_len), nhc % (T_pad // chunk_len), 0, vt * BV),
+            ),
+        ),
+        interpret=_should_interpret_pallas(),
+    )(k_flat, v_flat, g_flat, b_flat)
+    return out_yv
+
+
+def _gdn_chunk_bridge_reference_from_pseudo(
+    q_flat,
+    k_flat,
+    g_flat,
+    yk,
+    yv,  # [NH, Nc, C, K] / [NH, Nc, C, V]
+    *,
+    T_pad: int,
+    chunk_len: int,
+    initial_state: Optional[jnp.ndarray],
+    output_dtype: jnp.dtype,
+    output_final_state: bool,
+):
+    NH, L, K = q_flat.shape
+    V = yv.shape[-1]
+    Nc = T_pad // chunk_len
+    C = chunk_len
+
+    # State per sequence/head
+    S0 = jnp.zeros((NH, K, V), dtype=jnp.float32) if initial_state is None else initial_state.astype(jnp.float32)
+
+    # Convenience views
+    def slice_chunk(x, n, d=None):
+        c0 = n * C
+        if d is None:
+            return x[:, c0 : c0 + C]
+        else:
+            return x[:, c0 : c0 + C, :d]
+
+    outs = []
+    S = S0
+
+    for ci in range(Nc):
+        q_c = slice_chunk(q_flat, ci)  # [NH, C, K]
+        k_c = slice_chunk(k_flat, ci)  # [NH, C, K]
+        g_c = slice_chunk(g_flat, ci, d=None)  # [NH, C]
+        g_cum = jnp.cumsum(g_c, axis=1)  # [NH, C]
+        eg_cum = jnp.exp(g_cum)
+
+        yk_c = yk[:, ci]  # [NH, C, K]
+        yv_c = yv[:, ci]  # [NH, C, V]
+
+        # predicted by previous state within chunk & innovation
+        v_prime = jnp.einsum("nck,nkv->ncv", yk_c, S)  # [NH, C, V]
+        v_new = yv_c - v_prime
+
+        # inter-chunk term (from decayed state)
+        inter = jnp.einsum("nck,nkv->ncv", q_c * eg_cum[..., None], S)
+
+        # in-chunk "attention-like" strictly lower-triangular mixing with relative decays
+        # attn_ij = <q_i, k_j> * exp(g_cum[i] - g_cum[j]) for j<=i else 0
+        dots = jnp.einsum("nck,njk->ncj", q_c, k_c)  # [NH, C, C]
+        decay = jnp.exp(g_cum[..., None] - g_cum[:, None, :])  # [NH, C, C]
+        attn = dots * jnp.tril(decay)  # mask strict upper
+        out_c = inter + jnp.einsum("ncj,njv->ncv", attn, v_new)  # [NH, C, V]
+        outs.append(out_c.astype(output_dtype))
+
+        # state update to the next chunk
+        g_tail = g_cum[:, -1]  # [NH]
+        decay_tail = jnp.exp(g_tail)[:, None, None]  # [NH,1,1]
+        dw_full = jnp.exp(g_tail[:, None] - g_cum)  # [NH, C]
+        add = jnp.einsum("nck,ncv->nkv", k_c * dw_full[..., None], v_new)
+        S = S * decay_tail + add
+
+    out = jnp.concatenate(outs, axis=1)  # [NH, T_pad, V]
+    return (out, S) if output_final_state else (out, None)
+
+
+def _chunk_gated_delta_rule_flash_split(
     query,
     key,
     value,
@@ -1401,298 +1513,107 @@ def _chunk_gated_delta_rule_flash_tiled(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = True,
     head_first: bool = False,
-    offsets: Optional[jnp.ndarray] = None,
 ):
-    if not head_first:
-        Batch = query.resolve_axis("batch")
-        Pos = query.resolve_axis("position")
-        Heads = query.resolve_axis("heads")
-        Dk = query.resolve_axis("k_head_dim")
-        Dv = value.resolve_axis("v_head_dim")
-        B_, L_, H_, K_ = Batch.size, Pos.size, Heads.size, Dk.size
-        V_ = Dv.size
-        NH = B_ * H_
-
-        q_bhlk = hax.rearrange(query, (Batch, Heads, Pos, Dk)).array
-        k_bhlk = hax.rearrange(key, (Batch, Heads, Pos, Dk)).array
-        v_bhlv = hax.rearrange(value, (Batch, Heads, Pos, Dv)).array
-        g_bhl = hax.rearrange(g, (Batch, Heads, Pos)).array
-        b_bhl = hax.rearrange(beta, (Batch, Heads, Pos)).array
+    # Shapes & flatten BH→NH
+    if head_first:
+        B, H, L, K = query.shape[:4]
+        V = value.shape[-1]
+        q_bhlk, k_bhlk = query, key
+        v_bhlv = value
+        g_bhl, b_bhl = g, beta
     else:
-        Batch = query.resolve_axis("batch")
-        Heads = query.resolve_axis("heads")
-        Pos = query.resolve_axis("position")
-        Dk = query.resolve_axis("k_head_dim")
-        Dv = value.resolve_axis("v_head_dim")
-        B_, H_, L_, K_ = Batch.size, Heads.size, Pos.size, Dk.size
-        V_ = Dv.size
-        NH = B_ * H_
-        q_bhlk = query.array
-        k_bhlk = key.array
-        v_bhlv = value.array
-        g_bhl = g.array
-        b_bhl = beta.array
+        B, L, H, K = query.shape[:4]
+        V = value.shape[-1]
+        q_bhlk = jnp.transpose(query, (0, 2, 1, 3))  # [B,H,L,K]
+        k_bhlk = jnp.transpose(key, (0, 2, 1, 3))
+        v_bhlv = jnp.transpose(value, (0, 2, 1, 3))  # [B,H,L,V]
+        g_bhl = jnp.transpose(g, (0, 2, 1))  # [B,H,L]
+        b_bhl = jnp.transpose(beta, (0, 2, 1))
 
-    q_flat = q_bhlk.reshape(NH, L_, K_)
-    k_flat = k_bhlk.reshape(NH, L_, K_)
-    v_flat = v_bhlv.reshape(NH, L_, V_)
-    g_flat = g_bhl.reshape(NH, L_)
-    b_flat = b_bhl.reshape(NH, L_)
+    NH = B * H
+    q_flat = q_bhlk.reshape(NH, L, K).astype(jnp.float32)
+    k_flat = k_bhlk.reshape(NH, L, K).astype(jnp.float32)
+    v_flat = v_bhlv.reshape(NH, L, V).astype(jnp.float32)
+    g_flat = g_bhl.reshape(NH, L).astype(jnp.float32)
+    b_flat = b_bhl.reshape(NH, L).astype(jnp.float32)
 
-    lengths = (
-        jnp.full((NH,), L_, dtype=jnp.int32)
-        if offsets is None
-        else (offsets.astype(jnp.int32)[1:] - offsets.astype(jnp.int32)[:-1])
-    )
+    # Optional L2-norm + scaling (kept in JAX for simplicity; can be moved into kernels)
+    if use_qk_l2norm_in_kernel:
+        eps = 1e-6
+        qn = jnp.sqrt(jnp.sum(q_flat * q_flat, axis=-1, keepdims=True) + eps)
+        kn = jnp.sqrt(jnp.sum(k_flat * k_flat, axis=-1, keepdims=True) + eps)
+        q_flat = (q_flat / jnp.maximum(qn, 1.0)) * (K**-0.5)
+        k_flat = k_flat / jnp.maximum(kn, 1.0)
+    else:
+        q_flat = q_flat * (K**-0.5)
 
-    T_pad = int(_ceil_div(L_, chunk_size) * chunk_size)
-    pad_amt = T_pad - L_
-    q_flat = _pad_L_axis(q_flat, pad_amt)
-    k_flat = _pad_L_axis(k_flat, pad_amt)
-    v_flat = _pad_L_axis(v_flat, pad_amt)
-    g_flat = _pad_L_axis(g_flat, pad_amt)
-    b_flat = _pad_L_axis(b_flat, pad_amt)
+    # Pad L to multiple of C
+    C = int(chunk_size)
+    Nc = (L + C - 1) // C
+    T_pad = Nc * C
 
-    init_flat = (
-        jnp.zeros((NH, K_, V_), dtype=jnp.float32)
-        if initial_state is None
-        else initial_state.reshape(NH, K_, V_).astype(jnp.float32)
-    )
+    def _pad_last(x, width, val=0.0):
+        pad = T_pad - width
+        if pad == 0:
+            return x
+        if x.ndim == 2:
+            return jnp.pad(x, ((0, 0), (0, pad)))
+        if x.ndim == 3:
+            return jnp.pad(x, ((0, 0), (0, pad), (0, 0)))
+        raise ValueError
 
-    tiles = _pick_tiles(K_, V_)
-    BK, BV = int(tiles.BK), int(tiles.BV)
+    q_flat = _pad_last(q_flat, L)
+    k_flat = _pad_last(k_flat, L)
+    v_flat = _pad_last(v_flat, L)
+    g_flat = _pad_last(g_flat, L)
+    b_flat = _pad_last(b_flat, L)
 
-    out_struct = jax.ShapeDtypeStruct((NH, T_pad, V_), value.dtype)
-    final_struct = jax.ShapeDtypeStruct((NH, K_, V_), jnp.float32)
+    # --- Choose tiles (can be autotuned later) ---
+    BK = min(64 if K >= 128 else 32, K)
+    BV = min(64 if V >= 128 else 32, V)
 
-    kernel_partial = functools.partial(
-        _gdn_chunk_fwd_kernel,
+    # --- Stage A: UT for YK and YV with grid tiling ---
+    yk = _prepare_yk_pallas(k_flat, g_flat, b_flat, T_pad=T_pad, K=K, chunk_len=C, BK=BK)  # [NH,Nc,C,K]
+    yv = _prepare_yv_pallas(k_flat, v_flat, g_flat, b_flat, T_pad=T_pad, K=K, V=V, chunk_len=C, BK=BK, BV=BV)
+
+    # --- Stage B: Bridge + outputs from pseudo streams ---
+    out_flat, S_final = _gdn_chunk_bridge_reference_from_pseudo(
+        q_flat,
+        k_flat,
+        g_flat,
+        yk,
+        yv,
         T_pad=T_pad,
-        K=K_,
-        V=V_,
-        chunk_len=int(chunk_size),
-        head_first=head_first,
-        store_final_state=output_final_state,
-        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-        BK=BK,
-        BV=BV,
-    )
-
-    out_flat, final_flat = pl.pallas_call(
-        kernel_partial,
-        out_shape=(out_struct, final_struct),
-        grid=(NH,),
-        in_specs=(
-            pl.BlockSpec((1, T_pad, K_), lambda bid: (bid, 0, 0)),
-            pl.BlockSpec((1, T_pad, K_), lambda bid: (bid, 0, 0)),
-            pl.BlockSpec((1, T_pad, V_), lambda bid: (bid, 0, 0)),
-            pl.BlockSpec((1, T_pad), lambda bid: (bid, 0)),
-            pl.BlockSpec((1, T_pad), lambda bid: (bid, 0)),
-            pl.BlockSpec((1, K_, V_), lambda bid: (bid, 0, 0)),
-            pl.BlockSpec((1,), lambda bid: (bid,)),  # lengths
-        ),
-        out_specs=(
-            pl.BlockSpec((1, T_pad, V_), lambda bid: (bid, 0, 0)),
-            pl.BlockSpec((1, K_, V_), lambda bid: (bid, 0, 0)),
-        ),
-        interpret=_should_interpret_pallas(),
-    )(q_flat, k_flat, v_flat, g_flat, b_flat, init_flat, lengths)
-
-    out_trim = out_flat[:, :L_, :]
-    if not head_first:
-        out_bhLv = out_trim.reshape(B_, H_, L_, V_)
-        out_named = hax.named(out_bhLv, (Batch, Heads, Pos, Dv))
-        out_final = hax.rearrange(out_named, (Batch, Pos, Heads, Dv))
-        final = final_flat.reshape(B_, H_, K_, V_) if output_final_state else None
-        return out_final, final
-    else:
-        out_bHLv = out_trim.reshape(B_, H_, L_, V_)
-        out_named = hax.named(out_bHLv, (Batch, Heads, Pos, Dv))
-        final = final_flat.reshape(B_, H_, K_, V_) if output_final_state else None
-        return out_named, final
-
-
-@functools.partial(jax.custom_vjp, nondiff_argnums=(6, 7, 8, 9, 10, 11))
-def _chunk_gdn_flash_array(
-    q_arr: jnp.ndarray,  # [B,L,H,K] or [B,H,L,K]
-    k_arr: jnp.ndarray,
-    v_arr: jnp.ndarray,
-    g_arr: jnp.ndarray,  # [B,L,H] or [B,H,L]
-    beta_arr: jnp.ndarray,  # [B,L,H] or [B,H,L]
-    initial_state: Optional[jnp.ndarray],  # [B,H,K,V]
-    chunk_size: int,
-    output_final_state: bool,
-    use_qk_l2norm_in_kernel: bool,
-    head_first: bool,
-    use_varlen: bool,
-    offsets: Optional[jnp.ndarray],
-):
-    if not head_first:
-        Batch = Axis("batch", q_arr.shape[0])
-        Pos = Axis("position", q_arr.shape[1])
-        Heads = Axis("heads", q_arr.shape[2])
-        Dk = Axis("k_head_dim", q_arr.shape[3])
-        Dv = Axis("v_head_dim", v_arr.shape[3])
-        q = hax.named(q_arr, (Batch, Pos, Heads, Dk))
-        k = hax.named(k_arr, (Batch, Pos, Heads, Dk))
-        v = hax.named(v_arr, (Batch, Pos, Heads, Dv))
-        gg = hax.named(g_arr, (Batch, Pos, Heads))
-        bb = hax.named(beta_arr, (Batch, Pos, Heads))
-    else:
-        Batch = Axis("batch", q_arr.shape[0])
-        Heads = Axis("heads", q_arr.shape[1])
-        Pos = Axis("position", q_arr.shape[2])
-        Dk = Axis("k_head_dim", q_arr.shape[3])
-        Dv = Axis("v_head_dim", v_arr.shape[3])
-        q = hax.named(q_arr, (Batch, Heads, Pos, Dk))
-        k = hax.named(k_arr, (Batch, Heads, Pos, Dk))
-        v = hax.named(v_arr, (Batch, Heads, Pos, Dv))
-        gg = hax.named(g_arr, (Batch, Heads, Pos))
-        bb = hax.named(beta_arr, (Batch, Heads, Pos))
-
-    out_named, final = _chunk_gated_delta_rule_flash_tiled(
-        q,
-        k,
-        v,
-        gg,
-        bb,
-        chunk_size=chunk_size,
-        initial_state=initial_state,
+        chunk_len=C,
+        initial_state=(None if initial_state is None else initial_state.reshape(NH, K, V)),
+        output_dtype=value.dtype,
         output_final_state=output_final_state,
-        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-        head_first=head_first,
-        offsets=offsets if use_varlen else None,
     )
-    return out_named.array, final
+
+    # Trim and reshape back to [B, Pos, H, V]
+    out_trim = out_flat[:, :L, :]
+    out_bHLv = out_trim.reshape(B, H, L, V)
+    out_named = out_bHLv if head_first else jnp.transpose(out_bHLv, (0, 2, 1, 3))
+    S_out = None if not output_final_state else S_final.reshape(B, H, K, V)
+    return out_named, S_out
 
 
-def _chunk_gdn_flash_array_fwd(
-    q_arr,
-    k_arr,
-    v_arr,
-    g_arr,
-    beta_arr,
-    initial_state,
-    chunk_size,
-    output_final_state,
-    use_qk_l2norm_in_kernel,
-    head_first,
-    use_varlen,
-    offsets,
-):
-    out_arr, final = _chunk_gdn_flash_array(
-        q_arr,
-        k_arr,
-        v_arr,
-        g_arr,
-        beta_arr,
-        initial_state,
-        chunk_size,
-        output_final_state,
-        use_qk_l2norm_in_kernel,
-        head_first,
-        use_varlen,
-        offsets,
-    )
-    residual = (
-        q_arr,
-        k_arr,
-        v_arr,
-        g_arr,
-        beta_arr,
-        initial_state,
-        chunk_size,
-        use_qk_l2norm_in_kernel,
-        head_first,
-        use_varlen,
-        offsets,
-    )
-    return (out_arr, final), residual
-
-
-def _chunk_gdn_flash_array_bwd(
-    chunk_size,
-    output_final_state,
-    use_qk_l2norm_in_kernel,
-    head_first,
-    use_varlen,
-    offsets,
-    residual,
-    tangents,
-):
-    (
-        q_arr,
-        k_arr,
-        v_arr,
-        g_arr,
-        beta_arr,
-        init_arr,
-        chunk_size_res,
-        use_norm_res,
-        head_first_res,
-        use_varlen_res,
-        offsets_res,
-    ) = residual
-    dout, dfinal = tangents
-
-    # Rematerialize via reference kernel for VJP (memory friendly and already parity-checked)
-    Batch = Axis("batch", q_arr.shape[0])
-    if not head_first_res:
-        Pos = Axis("position", q_arr.shape[1])
-        Heads = Axis("heads", q_arr.shape[2])
-        Dk = Axis("k_head_dim", q_arr.shape[3])
-        Dv = Axis("v_head_dim", v_arr.shape[3])
-        qn = hax.named(q_arr, (Batch, Pos, Heads, Dk))
-        kn = hax.named(k_arr, (Batch, Pos, Heads, Dk))
-        vn = hax.named(v_arr, (Batch, Pos, Heads, Dv))
-        gn = hax.named(g_arr, (Batch, Pos, Heads))
-        bn = hax.named(beta_arr, (Batch, Pos, Heads))
+def _wrap_chunk_out_as_named(out_arr, query, value, *, head_first: bool):
+    """Return the chunk output as NamedArray with the same axes as the reference path."""
+    if not head_first:
+        # out_arr is (B, L, H, V) and value.axes is (Batch, Position, Heads, VHeadDim)
+        return hax.named(out_arr, value.axes)
     else:
-        Heads = Axis("heads", q_arr.shape[1])
-        Pos = Axis("position", q_arr.shape[2])
-        Dk = Axis("k_head_dim", q_arr.shape[3])
-        Dv = Axis("v_head_dim", v_arr.shape[3])
-        qn = hax.named(q_arr, (Batch, Heads, Pos, Dk))
-        kn = hax.named(k_arr, (Batch, Heads, Pos, Dk))
-        vn = hax.named(v_arr, (Batch, Heads, Pos, Dv))
-        gn = hax.named(g_arr, (Batch, Heads, Pos))
-        bn = hax.named(beta_arr, (Batch, Heads, Pos))
-
-    def _ref_fun(q_in, k_in, v_in, g_in, beta_in, init_in):
-        out_ref, fin_ref = _chunk_gated_delta_rule_reference(
-            q_in,
-            k_in,
-            v_in,
-            g_in,
-            beta_in,
-            chunk_size=chunk_size_res,
-            initial_state=init_in,
-            output_final_state=True,
-            use_qk_l2norm_in_kernel=use_norm_res,
+        # out_arr is (B, H, L, V)
+        return hax.named(
+            out_arr,
+            (
+                query.resolve_axis("batch"),
+                query.resolve_axis("heads"),
+                query.resolve_axis("position"),
+                value.resolve_axis("v_head_dim"),
+            ),
         )
-        return out_ref.array, fin_ref
-
-    init_default = (
-        init_arr
-        if init_arr is not None
-        else jnp.zeros((q_arr.shape[0], q_arr.shape[2], q_arr.shape[3], v_arr.shape[3]), dtype=jnp.float32)
-    )
-    _, vjp_fun = jax.vjp(_ref_fun, qn, kn, vn, gn, bn, init_default)
-    dout_arr = dout if not isinstance(dout, NamedArray) else dout.array
-    dfinal_arr = jnp.zeros_like(init_default) if dfinal is None else dfinal
-    gq, gk, gv, gg, gb, ginit = vjp_fun((dout_arr, dfinal_arr))
-
-    return (
-        gq.array if isinstance(gq, NamedArray) else gq,
-        gk.array if isinstance(gk, NamedArray) else gk,
-        gv.array if isinstance(gv, NamedArray) else gv,
-        gg.array if isinstance(gg, NamedArray) else gg,
-        gb.array if isinstance(gb, NamedArray) else gb,
-        (None if init_arr is None else ginit),
-    )
-
-
-_chunk_gdn_flash_array.defvjp(_chunk_gdn_flash_array_fwd, _chunk_gdn_flash_array_bwd)
 
 
 def chunk_gated_delta_rule(
@@ -1712,33 +1633,19 @@ def chunk_gated_delta_rule(
     use_varlen: bool = False,
 ) -> tuple[NamedArray, Optional[jnp.ndarray]]:
     if use_flash:
-        out_arr, fin = _chunk_gdn_flash_array(
+        out_arr, fin = _chunk_gated_delta_rule_flash_split(
             query.array,
             key.array,
             value.array,
             g.array,
             beta.array,
-            initial_state,
-            chunk_size,
-            output_final_state,
-            use_qk_l2norm_in_kernel,
-            head_first,
-            use_varlen,
-            offsets,
+            chunk_size=chunk_size,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            head_first=head_first,
         )
-        out_named = hax.named(
-            out_arr,
-            (
-                value.axes
-                if not head_first
-                else (
-                    query.resolve_axis("batch"),
-                    query.resolve_axis("heads"),
-                    query.resolve_axis("position"),
-                    value.resolve_axis("v_head_dim"),
-                )
-            ),
-        )
+        out_named = _wrap_chunk_out_as_named(out_arr, query, value, head_first=head_first)
         return out_named, fin
 
     # reference fallback

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -626,7 +626,7 @@ def _gdn_recurrent_fwd_kernel_tiled_2d(
     has_initial_state,
     is_beta_headwise,
     scale,
-    head_first_layout: bool,  # NEW: tells us how to squeeze 4-D tiles
+    head_first_layout: bool,
 ):
     # ---- Local (tile) views; squeeze the 1-sized dims to get 2-D/1-D arrays ----
     if head_first_layout:
@@ -1283,225 +1283,189 @@ def _build_T_from_kbeta(
     return T
 
 
-# --- per-chunk UT to form yk = T @ (βK ⊙ exp(g_cum)) ---
-def _gdn_chunk_prepare_yk_kernel(
+def _gdn_chunk_fwd_kernel_fused(
+    q_ref,  # [NH, T_pad, K]
     k_ref,  # [NH, T_pad, K]
+    v_ref,  # [NH, T_pad, V_pad]
     g_ref,  # [NH, T_pad]
     beta_ref,  # [NH, T_pad]
-    yk_ref,  # [NH, Nc, C, K]  (output)
+    s_prev_ref,  # [NH, K, V_pad]
+    ci_ref,  # [1]  int32 (chunk index)
+    lengths_ref,  # [NH] int32 (per sequence length)
+    out_tile_ref,  # [NH, 1, C, BV]
+    s_tile_ref,  # [NH, 1, K, BV]
     *,
     T_pad: int,
     K: int,
+    V_pad: int,
     chunk_len: int,
     BK: int,
+    BV: int,
 ):
-    nhc = pl.program_id(0)
-    kt = pl.program_id(1)
-    Nc = T_pad // chunk_len
-    nh = nhc // Nc
-    ci = nhc - nh * Nc
-    k0 = kt * BK  # K-tile start (BK already clamped ≤ K)
+    nh = pl.program_id(0)
+    vt = pl.program_id(1)
+    ci = ci_ref[dslice(0, 1)][0].astype(jnp.int32)
 
-    c0 = ci * chunk_len
-    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C,K)
+    # --- chunk start, active length for this sequence ---
+    c0 = ci * jnp.int32(chunk_len)
+    Lnh = lengths_ref[dslice(nh, 1)][0].astype(jnp.int32)
+    rem = Lnh - c0  # remaining tokens from this chunk start
+    active = jnp.clip(rem, jnp.int32(0), jnp.int32(chunk_len))  # in [0, C]
+
+    # Dynamic row mask for positions < active (float32 for mul)
+    ar = lax.iota(jnp.int32, chunk_len)  # [0..C-1]
+    m = (ar < active).astype(jnp.float32)  # (C,)
+
+    # --- Read chunk slices (C = chunk_len) ---
+    q_c = q_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C, K)
+    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C, K)
+    v_c = v_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(v0 := vt * jnp.int32(BV), BV)][0].astype(jnp.float32)
     g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)  # (C,)
     b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)  # (C,)
+    S_prev_v = s_prev_ref[dslice(nh, 1), dslice(0, K), dslice(v0, BV)][0].astype(jnp.float32)  # (K, BV)
 
-    g_cum = jnp.cumsum(g_c, axis=0).astype(jnp.float32)
-    Tmat = _build_T_from_kbeta(k_c, b_c, g_cum, K=K, BK=BK)  # (C,C)
+    # Apply row masks to q,k,v,β  (positions ≥ active become zero)
+    q_c = q_c * m[:, None]
+    k_c = k_c * m[:, None]
+    v_c = v_c * m[:, None]
+    b_c = b_c * m
 
-    # rhs for YK: (β K) ⊙ exp(g_cum) row-wise
-    rhs_blk = jnp.exp(g_cum)[:, None] * (k_c * b_c[:, None])  # (C,K)
-    rhs_tile = lax.dynamic_slice(rhs_blk, (0, k0), (chunk_len, BK))  # (C,BK)
+    # --- g_cum and tail selection from last valid index (varlen-safe) ---
+    g_cum = jnp.cumsum(g_c, axis=0)  # (C,)
 
-    # YK_tile = T @ rhs_tile  → (C, BK)
-    # Implement as explicit sum to maintain identical accumulation order across dtypes
-    def col_body(c, acc):
-        col = lax.dynamic_slice(rhs_tile, (0, c), (chunk_len, 1))[:, 0]  # (C,)
-        y = Tmat @ col  # (C,)
-        return acc.at[:, c].set(y)
+    def _pick_tail(_):
+        return lax.dynamic_slice_in_dim(g_cum, active - 1, 1, axis=0)[0]
 
-    yk_tile = jnp.zeros((chunk_len, BK), dtype=jnp.float32)
-    yk_tile = lax.fori_loop(0, BK, col_body, yk_tile)
+    g_tail = lax.cond(active > 0, _pick_tail, lambda _: jnp.array(0.0, jnp.float32), operand=None)
 
-    yk_ref[dslice(nhc, 1), dslice(ci, 1), dslice(0, chunk_len), dslice(k0, BK)] = yk_tile[None, None, :, :]
+    eg = jnp.exp(g_cum).astype(jnp.float32)  # (C,) in (0,1]; safe (underflows to 0 OK)
 
+    # ============================================
+    # WY-style fast: Gram then A0, but NO D/D^{-1}
+    # ============================================
+    # G = (β K) @ K^T    (C×C), tiled over K
+    G = jnp.zeros((chunk_len, chunk_len), dtype=jnp.float32)
+    n_kb = (K + BK - 1) // BK
 
-def _prepare_yk_pallas(k_flat, g_flat, b_flat, *, T_pad, K, chunk_len, BK):
-    NH = k_flat.shape[0]
-    Nc = T_pad // chunk_len
-    out_yk = jnp.zeros((NH, Nc, chunk_len, K), dtype=jnp.float32)
+    def gram_body(kb, G_cur):
+        k0 = kb * BK
+        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))  # (C, BK)
+        kb_tile = k_tile * b_c[:, None]  # (C, BK) = βK
+        return G_cur + kb_tile @ jnp.transpose(k_tile)  # (C, C)
 
-    grid = (NH * Nc, (K + BK - 1) // BK)
-    (out_yk,) = pl.pallas_call(
-        functools.partial(
-            _gdn_chunk_prepare_yk_kernel,
-            T_pad=T_pad,
-            K=K,
-            chunk_len=int(chunk_len),
-            BK=int(BK),
-        ),
-        out_shape=(jax.ShapeDtypeStruct(out_yk.shape, out_yk.dtype),),
-        grid=grid,
-        in_specs=(
-            pl.BlockSpec((1, T_pad, K), lambda nhc, kt: (nhc // Nc, 0, 0)),  # k
-            pl.BlockSpec((1, T_pad), lambda nhc, kt: (nhc // Nc, 0)),  # g
-            pl.BlockSpec((1, T_pad), lambda nhc, kt: (nhc // Nc, 0)),  # β
-        ),
-        out_specs=(pl.BlockSpec((1, 1, chunk_len, BK), lambda nhc, kt: (nhc // Nc, nhc % Nc, 0, kt * BK)),),
-        interpret=_should_interpret_pallas(),
-    )(k_flat, g_flat, b_flat)
-    return out_yk
+    G = lax.fori_loop(0, n_kb, gram_body, G)
+    # A0 = - strictly-lower( G )
+    A0 = -jnp.tril(G, k=-1)  # (C, C)
 
-
-def _gdn_chunk_prepare_yv_kernel(
-    k_ref,  # [NH, T_pad, K]
-    v_ref,  # [NH, T_pad, V]
-    g_ref,  # [NH, T_pad]
-    beta_ref,  # [NH, T_pad]
-    yv_ref,  # [NH, Nc, C, V]
-    *,
-    T_pad: int,
-    K: int,
-    V: int,
-    chunk_len: int,
-    BK: int,  # used to scan K for dot_ij
-    BV: int,  # V tile
-):
-    nhc = pl.program_id(0)
-    vt = pl.program_id(1)
-    Nc = T_pad // chunk_len
-    nh = nhc // Nc
-    ci = nhc - nh * Nc
-    v0 = vt * BV  # V-tile start (BV already clamped ≤ V)
-
-    c0 = ci * chunk_len
-    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C,K)
-    v_c = v_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, V)][0].astype(jnp.float32)  # (C,V)
-    g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
-    b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
-
-    g_cum = jnp.cumsum(g_c, axis=0).astype(jnp.float32)
-    Tmat = _build_T_from_kbeta(k_c, b_c, g_cum, K=K, BK=BK)  # (C,C)
-
-    rhs_blk = v_c * b_c[:, None]  # (C,V)
-    rhs_tile = lax.dynamic_slice(rhs_blk, (0, v0), (chunk_len, BV))  # (C,BV)
-
-    def col_body(c, acc):
-        col = lax.dynamic_slice(rhs_tile, (0, c), (chunk_len, 1))[:, 0]  # (C,)
-        y = Tmat @ col  # (C,)
-        return acc.at[:, c].set(y)
-
+    # ===========================
+    # yv_tile via forward-sub:   (I - Ā) U = βV
+    # where Ā[i,j] = A0[i,j] * exp(g_i - g_j)
+    # ===========================
     yv_tile = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
-    yv_tile = lax.fori_loop(0, BV, col_body, yv_tile)
 
-    yv_ref[dslice(nhc, 1), dslice(ci, 1), dslice(0, chunk_len), dslice(v0, BV)] = yv_tile[None, None, :, :]
+    def fs_v(i, Y):
+        # rhs = β_i * v_i
+        rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]  # (BV,)
 
+        # accumulate sum_{j<i} A0[i,j] * exp(g_i - g_j) * U_j
+        def acc_v(j, acc):
+            aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+            decay_ij = jnp.exp(g_cum[i] - g_cum[j])  # in (0, 1]
+            uj = lax.dynamic_slice(Y, (j, 0), (1, BV))[0]  # (BV,)
+            return acc + (aij * decay_ij) * uj
 
-def _prepare_yv_pallas(k_flat, v_flat, g_flat, b_flat, *, T_pad, K, V, chunk_len, BK, BV):
-    NH = k_flat.shape[0]
-    Nc = T_pad // chunk_len
-    out_yv = jnp.zeros((NH, Nc, chunk_len, V), dtype=jnp.float32)
+        contrib = lax.fori_loop(0, i, acc_v, jnp.zeros((BV,), dtype=jnp.float32))
+        yi = rhs_i + contrib
+        return lax.dynamic_update_slice(Y, yi[None, :], (i, 0))
 
-    grid = (NH * Nc, (V + BV - 1) // BV)
-    (out_yv,) = pl.pallas_call(
-        functools.partial(
-            _gdn_chunk_prepare_yv_kernel,
-            T_pad=T_pad,
-            K=K,
-            V=V,
-            chunk_len=int(chunk_len),
-            BK=int(BK),
-            BV=int(BV),
-        ),
-        out_shape=(jax.ShapeDtypeStruct(out_yv.shape, out_yv.dtype),),
-        grid=grid,
-        in_specs=(
-            pl.BlockSpec((1, T_pad, K), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0, 0)),  # k
-            pl.BlockSpec((1, T_pad, V), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0, 0)),  # v
-            pl.BlockSpec((1, T_pad), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0)),  # g
-            pl.BlockSpec((1, T_pad), lambda nhc, vt: (nhc // (T_pad // chunk_len), 0)),  # β
-        ),
-        out_specs=(
-            pl.BlockSpec(
-                (1, 1, chunk_len, BV),
-                lambda nhc, vt: (nhc // (T_pad // chunk_len), nhc % (T_pad // chunk_len), 0, vt * BV),
-            ),
-        ),
-        interpret=_should_interpret_pallas(),
-    )(k_flat, v_flat, g_flat, b_flat)
-    return out_yv
+    yv_tile = lax.fori_loop(0, chunk_len, fs_v, yv_tile)
 
+    # ===========================
+    # yk_tile via forward-sub:   (I - Ā) W = e^{g} ⊙ (βK)
+    # ===========================
+    yk_tile = jnp.zeros((chunk_len, BK), dtype=jnp.float32)
 
-def _gdn_chunk_bridge_reference_from_pseudo(
-    q_flat,
-    k_flat,
-    g_flat,
-    yk,
-    yv,  # [NH, Nc, C, K] / [NH, Nc, C, V]
-    *,
-    T_pad: int,
-    chunk_len: int,
-    initial_state: Optional[jnp.ndarray],
-    output_dtype: jnp.dtype,
-    output_final_state: bool,
-):
-    NH, L, K = q_flat.shape
-    V = yv.shape[-1]
-    Nc = T_pad // chunk_len
-    C = chunk_len
+    def fs_k(kb, Y):
+        # do a small W recurrence for BK columns in this tile
+        k0 = kb * BK
+        # Prepare RHS tile once for all rows: e^{g} * β * K_tile
+        k_t = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))  # (C, BK)
+        rhs_tile = (eg[:, None] * (b_c[:, None] * k_t)).astype(jnp.float32)
 
-    # State per sequence/head
-    S0 = jnp.zeros((NH, K, V), dtype=jnp.float32) if initial_state is None else initial_state.astype(jnp.float32)
+        def fs_row(i, Ycur):
+            rhs_i = lax.dynamic_slice(rhs_tile, (i, 0), (1, BK))[0]  # (BK,)
 
-    # Convenience views
-    def slice_chunk(x, n, d=None):
-        c0 = n * C
-        if d is None:
-            return x[:, c0 : c0 + C]
-        else:
-            return x[:, c0 : c0 + C, :d]
+            def acc_k(j, acc):
+                aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+                decay_ij = jnp.exp(g_cum[i] - g_cum[j])  # in (0, 1]
+                wj = lax.dynamic_slice(Ycur, (j, 0), (1, BK))[0]  # (BK,)
+                return acc + (aij * decay_ij) * wj
 
-    outs = []
-    S = S0
+            contrib = lax.fori_loop(0, i, acc_k, jnp.zeros((BK,), dtype=jnp.float32))
+            yi = rhs_i + contrib
+            return lax.dynamic_update_slice(Ycur, yi[None, :], (i, 0))
 
-    for ci in range(Nc):
-        q_c = slice_chunk(q_flat, ci)  # [NH, C, K]
-        k_c = slice_chunk(k_flat, ci)  # [NH, C, K]
-        g_c = slice_chunk(g_flat, ci, d=None)  # [NH, C]
-        g_cum = jnp.cumsum(g_c, axis=1)  # [NH, C]
-        eg_cum = jnp.exp(g_cum)
+        return lax.fori_loop(0, chunk_len, fs_row, Y)
 
-        yk_c = yk[:, ci]  # [NH, C, K]
-        yv_c = yv[:, ci]  # [NH, C, V]
+    yk_tile = lax.fori_loop(0, n_kb, fs_k, yk_tile)
 
-        # predicted by previous state within chunk & innovation
-        v_prime = jnp.einsum("nck,nkv->ncv", yk_c, S)  # [NH, C, V]
-        v_new = yv_c - v_prime
+    # --- First pass accumulators using yk/yv as before ---
+    v_prime = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
+    inter = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
+    qk_raw = jnp.zeros((chunk_len, chunk_len), dtype=jnp.float32)
 
-        # inter-chunk term (from decayed state)
-        inter = jnp.einsum("nck,nkv->ncv", q_c * eg_cum[..., None], S)
+    def body_k1_acc(kb, acc):
+        vpr_acc, inter_acc, qk_acc = acc
+        k0 = kb * BK
+        q_tile = lax.dynamic_slice(q_c, (0, k0), (chunk_len, BK))  # (C, BK)
+        # yk over this tile:
+        yk_t = lax.dynamic_slice(yk_tile, (0, 0), (chunk_len, BK))
+        S_kv = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))  # (BK, BV)
+        vpr_acc = vpr_acc + yk_t @ S_kv
+        inter_acc = inter_acc + (q_tile * eg[:, None]) @ S_kv
+        qk_acc = qk_acc + q_tile @ jnp.transpose(lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK)))
+        return (vpr_acc, inter_acc, qk_acc)
 
-        # in-chunk "attention-like" strictly lower-triangular mixing with relative decays
-        # attn_ij = <q_i, k_j> * exp(g_cum[i] - g_cum[j]) for j<=i else 0
-        dots = jnp.einsum("nck,njk->ncj", q_c, k_c)  # [NH, C, C]
-        decay = jnp.exp(g_cum[..., None] - g_cum[:, None, :])  # [NH, C, C]
-        attn = dots * jnp.tril(decay)  # mask strict upper
-        out_c = inter + jnp.einsum("ncj,njv->ncv", attn, v_new)  # [NH, C, V]
-        outs.append(out_c.astype(output_dtype))
+    v_prime, inter, qk_raw = lax.fori_loop(0, n_kb, body_k1_acc, (v_prime, inter, qk_raw))
 
-        # state update to the next chunk
-        g_tail = g_cum[:, -1]  # [NH]
-        decay_tail = jnp.exp(g_tail)[:, None, None]  # [NH,1,1]
-        dw_full = jnp.exp(g_tail[:, None] - g_cum)  # [NH, C]
-        add = jnp.einsum("nck,ncv->nkv", k_c * dw_full[..., None], v_new)
-        S = S * decay_tail + add
+    # --- Triangular "attention-like" mix with relative decays (unchanged) ---
+    decay = jnp.exp(g_cum[:, None] - g_cum[None, :])  # (C, C) in (0,1]
+    attn = jnp.tril(decay * qk_raw)  # (C, C)
 
-    out = jnp.concatenate(outs, axis=1)  # [NH, T_pad, V]
-    return (out, S) if output_final_state else (out, None)
+    v_new = yv_tile - v_prime  # (C, BV)
+    out = inter + attn @ v_new  # (C, BV)
+
+    # --- Update S for this V tile (unchanged) ---
+    alpha_tail = jnp.exp(g_tail).astype(jnp.float32)
+    dw = jnp.exp(g_tail - g_cum).astype(jnp.float32) * m  # (C,)
+    v_weighted = v_new * dw[:, None]  # (C, BV)
+
+    S_add = jnp.zeros((K, BV), dtype=jnp.float32)
+
+    def body_k2(kb, S_acc):
+        k0 = kb * BK
+        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))  # (C, BK)
+        S_add_tile = jnp.transpose(k_tile) @ v_weighted  # (BK, BV)
+        return lax.dynamic_update_slice(S_acc, S_add_tile, (k0, 0))
+
+    S_add = lax.fori_loop(0, n_kb, body_k2, S_add)
+
+    def write_k3(kb, _):
+        k0 = kb * BK
+        S_prev_tile = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))  # (BK, BV)
+        S_new_tile = alpha_tail * S_prev_tile + lax.dynamic_slice(S_add, (k0, 0), (BK, BV))
+        s_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(k0, BK), dslice(0, BV)] = S_new_tile[None, None, :, :]
+        return ()
+
+    _ = lax.fori_loop(0, n_kb, write_k3, ())
+
+    # --- Write out the chunk’s output for this V-tile ---
+    out_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, chunk_len), dslice(0, BV)] = out.astype(out_tile_ref.dtype)[
+        None, None, :, :
+    ]
 
 
-def _chunk_gated_delta_rule_flash_split(
+def _chunk_gated_delta_rule_flash_fused(
     query,
     key,
     value,
@@ -1509,25 +1473,27 @@ def _chunk_gated_delta_rule_flash_split(
     beta,
     *,
     chunk_size: int = 64,
-    initial_state: Optional[jnp.ndarray] = None,
+    initial_state: Optional[jnp.ndarray] = None,  # [B,H,K,V] or [NH,K,V]
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = True,
     head_first: bool = False,
+    lengths: Optional[jnp.ndarray] = None,
+    offsets: Optional[jnp.ndarray] = None,  # Optional: if provided, compute lengths
+    use_varlen: bool = False,  # keep existing flag for explicit control
 ):
-    # Shapes & flatten BH→NH
+    # ----- reshape / layout -----
     if head_first:
         B, H, L, K = query.shape[:4]
         V = value.shape[-1]
-        q_bhlk, k_bhlk = query, key
-        v_bhlv = value
+        q_bhlk, k_bhlk, v_bhlv = query, key, value
         g_bhl, b_bhl = g, beta
     else:
         B, L, H, K = query.shape[:4]
         V = value.shape[-1]
-        q_bhlk = jnp.transpose(query, (0, 2, 1, 3))  # [B,H,L,K]
+        q_bhlk = jnp.transpose(query, (0, 2, 1, 3))
         k_bhlk = jnp.transpose(key, (0, 2, 1, 3))
-        v_bhlv = jnp.transpose(value, (0, 2, 1, 3))  # [B,H,L,V]
-        g_bhl = jnp.transpose(g, (0, 2, 1))  # [B,H,L]
+        v_bhlv = jnp.transpose(value, (0, 2, 1, 3))
+        g_bhl = jnp.transpose(g, (0, 2, 1))
         b_bhl = jnp.transpose(beta, (0, 2, 1))
 
     NH = B * H
@@ -1537,23 +1503,42 @@ def _chunk_gated_delta_rule_flash_split(
     g_flat = g_bhl.reshape(NH, L).astype(jnp.float32)
     b_flat = b_bhl.reshape(NH, L).astype(jnp.float32)
 
-    # Optional L2-norm + scaling (kept in JAX for simplicity; can be moved into kernels)
+    # --- varlen: compute lengths_flat in tokens per NH sequence ---
+    if use_varlen:
+        if lengths is not None:
+            lengths_flat = lengths.reshape(-1).astype(jnp.int32)
+            assert lengths_flat.shape[0] == NH
+        elif offsets is not None:
+            # offsets can be NH or NH+1; if NH+1, do diff
+            off = offsets.reshape(-1).astype(jnp.int32)
+            if off.shape[0] == NH + 1:
+                lengths_flat = off[1:] - off[:-1]
+            else:
+                lengths_flat = off
+            assert lengths_flat.shape[0] == NH
+        else:
+            raise ValueError("use_varlen=True requires `lengths` or `offsets`.")
+        # Clip to [0, L] in case of over-reporting
+        lengths_flat = jnp.clip(lengths_flat, 0, jnp.int32(L))
+    else:
+        lengths_flat = jnp.full((NH,), L, dtype=jnp.int32)
+
+    # Optional L2-norm + scaling (outside kernel)
     if use_qk_l2norm_in_kernel:
         eps = 1e-6
         qn = jnp.sqrt(jnp.sum(q_flat * q_flat, axis=-1, keepdims=True) + eps)
         kn = jnp.sqrt(jnp.sum(k_flat * k_flat, axis=-1, keepdims=True) + eps)
-        q_flat = (q_flat / jnp.maximum(qn, 1.0)) * (K**-0.5)
-        k_flat = k_flat / jnp.maximum(kn, 1.0)
+        q_flat = (q_flat / jnp.where(qn > 0.0, qn, 1.0)) * (K**-0.5)
+        k_flat = k_flat / jnp.where(kn > 0.0, kn, 1.0)
     else:
         q_flat = q_flat * (K**-0.5)
 
-    # Pad L to multiple of C
     C = int(chunk_size)
     Nc = (L + C - 1) // C
     T_pad = Nc * C
 
-    def _pad_last(x, width, val=0.0):
-        pad = T_pad - width
+    def _pad_last(x, w):
+        pad = T_pad - w
         if pad == 0:
             return x
         if x.ndim == 2:
@@ -1562,40 +1547,93 @@ def _chunk_gated_delta_rule_flash_split(
             return jnp.pad(x, ((0, 0), (0, pad), (0, 0)))
         raise ValueError
 
+    # Pad time to whole chunks; lengths remain in [0, L] and are used inside kernel
     q_flat = _pad_last(q_flat, L)
     k_flat = _pad_last(k_flat, L)
     v_flat = _pad_last(v_flat, L)
     g_flat = _pad_last(g_flat, L)
     b_flat = _pad_last(b_flat, L)
 
-    # --- Choose tiles (can be autotuned later) ---
     BK = min(64 if K >= 128 else 32, K)
     BV = min(64 if V >= 128 else 32, V)
+    V_pad = ((V + BV - 1) // BV) * BV
+    if V_pad != V:
+        v_flat = jnp.pad(v_flat, ((0, 0), (0, 0), (0, V_pad - V)))
 
-    # --- Stage A: UT for YK and YV with grid tiling ---
-    yk = _prepare_yk_pallas(k_flat, g_flat, b_flat, T_pad=T_pad, K=K, chunk_len=C, BK=BK)  # [NH,Nc,C,K]
-    yv = _prepare_yv_pallas(k_flat, v_flat, g_flat, b_flat, T_pad=T_pad, K=K, V=V, chunk_len=C, BK=BK, BV=BV)
+    # Initial S (NH,K,V_pad)
+    if initial_state is None:
+        S = jnp.zeros((NH, K, V_pad), dtype=jnp.float32)
+    else:
+        init = initial_state.astype(jnp.float32)
+        if init.ndim == 4:  # [B,H,K,V]
+            S = init.reshape(NH, K, init.shape[-1])
+        else:
+            S = init
+        if S.shape[-1] != V_pad:
+            S = jnp.pad(S, ((0, 0), (0, 0), (0, V_pad - S.shape[-1])))
 
-    # --- Stage B: Bridge + outputs from pseudo streams ---
-    out_flat, S_final = _gdn_chunk_bridge_reference_from_pseudo(
-        q_flat,
-        k_flat,
-        g_flat,
-        yk,
-        yv,
+    out_pad = jnp.zeros((NH, T_pad, V_pad), dtype=value.dtype)
+
+    kernel = functools.partial(
+        _gdn_chunk_fwd_kernel_fused,
         T_pad=T_pad,
-        chunk_len=C,
-        initial_state=(None if initial_state is None else initial_state.reshape(NH, K, V)),
-        output_dtype=value.dtype,
-        output_final_state=output_final_state,
+        K=int(K),
+        V_pad=int(V_pad),
+        chunk_len=int(C),
+        BK=int(BK),
+        BV=int(BV),
     )
 
-    # Trim and reshape back to [B, Pos, H, V]
-    out_trim = out_flat[:, :L, :]
+    n_vtiles = V_pad // BV
+    # out_tile_struct = jax.ShapeDtypeStruct((NH, 1, C, BV), value.dtype)
+    # s_tile_struct = jax.ShapeDtypeStruct((NH, 1, K, BV), jnp.float32)
+
+    in_specs = (
+        pl.BlockSpec((1, T_pad, K), lambda nh, vt: (nh, 0, 0)),  # q
+        pl.BlockSpec((1, T_pad, K), lambda nh, vt: (nh, 0, 0)),  # k
+        pl.BlockSpec((1, T_pad, V_pad), lambda nh, vt: (nh, 0, 0)),  # v
+        pl.BlockSpec((1, T_pad), lambda nh, vt: (nh, 0)),  # g
+        pl.BlockSpec((1, T_pad), lambda nh, vt: (nh, 0)),  # beta
+        pl.BlockSpec((1, K, BV), lambda nh, vt: (nh, 0, vt * BV)),  # S_prev tile
+        pl.BlockSpec((1,), lambda nh, vt: (0,)),  # ci
+        pl.BlockSpec((1,), lambda nh, vt: (nh,)),
+    )
+    out_specs = (
+        pl.BlockSpec((1, 1, C, BV), lambda nh, vt: (nh, vt, 0, 0)),  # out tile
+        pl.BlockSpec((1, 1, K, BV), lambda nh, vt: (nh, vt, 0, 0)),  # S tile
+    )
+
+    def one_chunk(carry, ci):
+        S_in, out_buf = carry
+        ci_ary = jnp.asarray([ci], dtype=jnp.int32)
+
+        out_tiles, s_tiles = pl.pallas_call(
+            kernel,
+            out_shape=(
+                jax.ShapeDtypeStruct((NH, n_vtiles, C, BV), value.dtype),
+                jax.ShapeDtypeStruct((NH, n_vtiles, K, BV), jnp.float32),
+            ),
+            grid=(NH, n_vtiles),
+            in_specs=in_specs,
+            out_specs=out_specs,
+            interpret=_should_interpret_pallas(),
+        )(q_flat, k_flat, v_flat, g_flat, b_flat, S_in, ci_ary, lengths_flat)
+
+        out_chunk = out_tiles.reshape(NH, C, n_vtiles * BV)[:, :, :V_pad]
+        s_chunk = s_tiles.reshape(NH, K, n_vtiles * BV)[:, :, :V_pad]
+
+        c0 = ci * C
+        out_buf = lax.dynamic_update_slice(out_buf, out_chunk.astype(out_buf.dtype), (0, c0, 0))
+        S_out = s_chunk
+        return (S_out, out_buf), None
+
+    (S_final, out_all), _ = lax.scan(one_chunk, (S, out_pad), jnp.arange(Nc, dtype=jnp.int32))
+
+    out_trim = out_all[:, :L, :V]
     out_bHLv = out_trim.reshape(B, H, L, V)
     out_named = out_bHLv if head_first else jnp.transpose(out_bHLv, (0, 2, 1, 3))
-    S_out = None if not output_final_state else S_final.reshape(B, H, K, V)
-    return out_named, S_out
+    S_ret = None if not output_final_state else S_final[:, :, :V].reshape(B, H, K, V)
+    return out_named, S_ret
 
 
 def _wrap_chunk_out_as_named(out_arr, query, value, *, head_first: bool):
@@ -1631,23 +1669,30 @@ def chunk_gated_delta_rule(
     head_first: bool = False,
     offsets: Optional[jnp.ndarray] = None,
     use_varlen: bool = False,
+    lengths: Optional[jnp.ndarray] = None,
 ) -> tuple[NamedArray, Optional[jnp.ndarray]]:
     if use_flash:
-        out_arr, fin = _chunk_gated_delta_rule_flash_split(
-            query.array,
-            key.array,
-            value.array,
-            g.array,
-            beta.array,
-            chunk_size=chunk_size,
-            initial_state=initial_state,
-            output_final_state=output_final_state,
-            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-            head_first=head_first,
-        )
-        out_named = _wrap_chunk_out_as_named(out_arr, query, value, head_first=head_first)
-        return out_named, fin
-
+        try:
+            out_arr, fin = _chunk_gated_delta_rule_flash_fused(
+                query.array,
+                key.array,
+                value.array,
+                g.array,
+                beta.array,
+                chunk_size=chunk_size,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                head_first=head_first,
+                lengths=lengths,
+                offsets=offsets,
+                use_varlen=use_varlen,
+            )
+            out_named = _wrap_chunk_out_as_named(out_arr, query, value, head_first=head_first)
+            return out_named, fin
+        except Exception:
+            if use_flash:
+                raise
     # reference fallback
     return _chunk_gated_delta_rule_reference(
         query,

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -29,16 +29,39 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import dataclasses
+import functools
+import os
 from typing import Optional, Tuple
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax import lax
+from jax.experimental import pallas as pl
+from jax._src.state.indexing import dslice
 
 import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, NamedArray
+
+_GDN_DBG = bool(int(os.environ.get("GDN_DEBUG_SHARDING", "0")))
+
+
+def _dbg(tag: str, arr):
+    if not _GDN_DBG:
+        return
+    try:
+        jax.debug.inspect_array_sharding(arr, callback=lambda s: print(f"[GDN][internal] {tag}: {s}"))
+    except Exception:
+        pass
+
+
+def _should_interpret_pallas() -> bool:
+    try:
+        platform = jax.devices()[0].platform
+    except RuntimeError:
+        platform = "cpu"
+    return platform == "cpu"
 
 
 # ---------- small utilities ----------
@@ -54,6 +77,58 @@ def _l2norm(x: NamedArray, axis: hax.AxisSelector, eps: float = 1e-6) -> NamedAr
     x32 = x.astype(jnp.float32)
     inv = hax.rsqrt(hax.sum(hax.square(x32), axis=axis) + jnp.asarray(eps, dtype=jnp.float32))
     return (x32 * inv).astype(x.dtype)
+
+
+def _rmsnorm_gated_reference(
+    x_2d: jnp.ndarray,
+    gate_2d: jnp.ndarray,
+    weight: jnp.ndarray,
+    eps: float,
+) -> jnp.ndarray:
+    """Fallback RMSNorm + SiLU gate."""
+
+    x32 = x_2d.astype(jnp.float32)
+    gate32 = gate_2d.astype(jnp.float32)
+    weight32 = weight.astype(jnp.float32)
+    inv = jax.lax.rsqrt(jnp.mean(x32 * x32, axis=-1, keepdims=True) + jnp.asarray(eps, dtype=jnp.float32))
+    y32 = x32 * inv * weight32[None, :]
+    gated32 = y32 * jax.nn.silu(gate32)
+    return gated32.astype(x_2d.dtype)
+
+
+def _fused_rmsnorm_gated_pallas(
+    x_2d: jnp.ndarray,
+    gate_2d: jnp.ndarray,
+    weight: jnp.ndarray,
+    eps: float,
+) -> jnp.ndarray:
+    n_rows, hidden_size = x_2d.shape
+
+    def kernel(x_ref, gate_ref, weight_ref, out_ref, *, eps):
+        x = x_ref[0, :].astype(jnp.float32)
+        gate = gate_ref[0, :].astype(jnp.float32)
+        weight = weight_ref[:].astype(jnp.float32)
+        eps32 = jnp.asarray(eps, dtype=jnp.float32)
+        inv = jax.lax.rsqrt(jnp.mean(x * x) + eps32)
+        y = x * inv * weight
+        gated = y * jax.nn.silu(gate)
+        out_ref[0, :] = gated.astype(out_ref.dtype)
+
+    kernel_partial = functools.partial(kernel, eps=float(eps))
+
+    out = pl.pallas_call(
+        kernel_partial,
+        out_shape=jax.ShapeDtypeStruct(x_2d.shape, x_2d.dtype),
+        grid=(n_rows,),
+        in_specs=[
+            pl.BlockSpec((1, hidden_size), lambda i: (i, 0)),
+            pl.BlockSpec((1, hidden_size), lambda i: (i, 0)),
+            pl.BlockSpec((hidden_size,), lambda i: (0,)),
+        ],
+        out_specs=pl.BlockSpec((1, hidden_size), lambda i: (i, 0)),
+        interpret=_should_interpret_pallas(),
+    )(x_2d, gate_2d, weight)
+    return out
 
 
 # ---------- depthwise conv: positional (lax) helpers with named wrappers ----------
@@ -75,13 +150,19 @@ def _causal_depthwise_conv1d_full(
     - rhs (w):    O=0, I=1, H=2  (we inject a singleton I=1 for depthwise)
     - out:        N=0, C=1, H=2
     """
+    in_dtype = x_ncl.dtype
     N, C, L = x_ncl.shape
     K = w_ck.shape[-1]
     # pad x on the left with K-1 zeros so that output length == L ("causal")
     x_pad = jnp.pad(x_ncl, ((0, 0), (0, 0), (K - 1, 0)))
-    w_oik = w_ck[:, None, :]  # (C, 1, K) → O=C, I=1, K
-    y = lax.conv_general_dilated(
-        lhs=x_pad,
+
+    # Upcast both sides to float32 for conv
+    x32 = x_pad.astype(jnp.float32)
+    w32 = w_ck.astype(jnp.float32)
+    w_oik = w32[:, None, :]  # (C, 1, K)
+
+    y32 = lax.conv_general_dilated(
+        lhs=x32,
         rhs=w_oik,
         window_strides=(1,),
         padding="VALID",
@@ -90,10 +171,13 @@ def _causal_depthwise_conv1d_full(
         precision=lax.Precision.HIGHEST,
         preferred_element_type=jnp.float32,
     )
+    _dbg("conv/full/y32", y32)
+
     if bias_c is not None:
-        y = y + bias_c[:, None]
-    y = jax.nn.silu(y)
-    return y
+        y32 = y32 + bias_c.astype(jnp.float32)[:, None]
+
+    y32 = jax.nn.silu(y32)
+    return y32.astype(in_dtype)
 
 
 def _causal_depthwise_conv1d_update(
@@ -116,48 +200,76 @@ def _causal_depthwise_conv1d_update(
 
     Used during decode to avoid re-convolving the entire history.
     """
-    x_hist = jnp.concatenate([prev_state_nck, x_ncl_1], axis=-1)  # (N, C, K+1)
-    y2 = lax.conv_general_dilated(
-        lhs=x_hist,
-        rhs=w_ck[:, None, :],
+    in_dtype = x_ncl_1.dtype
+
+    x_hist = jnp.concatenate([prev_state_nck, x_ncl_1], axis=-1)
+    x32 = x_hist.astype(jnp.float32)
+    w32 = w_ck.astype(jnp.float32)
+
+    y32_all = lax.conv_general_dilated(
+        lhs=x32,
+        rhs=w32[:, None, :],
         window_strides=(1,),
         padding="VALID",
         dimension_numbers=("NCH", "OIH", "NCH"),
-        feature_group_count=x_hist.shape[1],
+        feature_group_count=w32.shape[0],
         precision=lax.Precision.HIGHEST,
         preferred_element_type=jnp.float32,
     )
-    y = y2[..., -1:]  # (N, C, 1): the newest output sample
+    y32 = y32_all[..., -1:]
+    _dbg("conv/update/y32", y32)
+
     if bias_c is not None:
-        y = y + bias_c[:, None]
-    y = jax.nn.silu(y)
+        y32 = y32 + bias_c.astype(jnp.float32)[:, None]
+
+    y32 = jax.nn.silu(y32)
     new_state = jnp.concatenate([prev_state_nck[..., 1:], x_ncl_1], axis=-1)
-    return y, new_state
+
+    return y32.astype(in_dtype), new_state.astype(in_dtype)
 
 
-# ---------- Gated RMSNorm with external gate ----------
+# ---------- Fused Gated RMSNorm ----------
 
 
-class GatedRmsNorm(eqx.Module):
-    """RMSNorm(x) * SiLU(gate)"""
+class FusedRMSNormGated(eqx.Module):
+    """RMSNorm(x) * SiLU(gate) using an optional fused Pallas kernel."""
 
     axis: Axis
     weight: NamedArray  # [axis]
     eps: float = eqx.field(default=1e-6, static=True)
+    use_flash: bool = eqx.field(default=True, static=True)
 
     @staticmethod
-    def init(axis: Axis, eps: float = 1e-6) -> "GatedRmsNorm":
-        return GatedRmsNorm(axis=axis, weight=hax.ones(axis), eps=eps)
+    def init(axis: Axis, eps: float = 1e-6, *, use_flash: bool = True) -> "FusedRMSNormGated":
+        return FusedRMSNormGated(axis=axis, weight=hax.ones(axis), eps=eps, use_flash=use_flash)
 
     def __call__(self, x: NamedArray, gate: NamedArray) -> NamedArray:
-        in_dtype = x.dtype
-        x32 = x.astype(jnp.float32)
-        var = hax.mean(hax.square(x32), axis=self.axis)
-        inv = hax.rsqrt(var + jnp.asarray(self.eps, dtype=jnp.float32))
-        y = (x32 * inv).astype(in_dtype)  # RMSNorm (from haliax/nn/normalization.py)
-        y = self.weight * y  # learned scale
-        gated = y * hnn.silu(gate)  # GDN's output gate
-        return gated.astype(in_dtype)
+        if x.resolve_axis(self.axis.name) != gate.resolve_axis(self.axis.name):
+            raise ValueError("x and gate must share the normalization axis")
+
+        # Move target axis to the end to make the flattened 2D view contiguous
+        other_axes = tuple(ax for ax in x.axes if ax.name != self.axis.name)
+        permuted_axes = other_axes + (self.axis,)
+        x_perm = hax.rearrange(x, permuted_axes)
+        gate_perm = hax.rearrange(gate, permuted_axes)
+
+        x_arr = x_perm.array.reshape(-1, self.axis.size)
+        gate_arr = gate_perm.array.reshape(-1, self.axis.size)
+        weight_arr = self.weight.array
+
+        if self.use_flash:
+            try:
+                out_arr = _fused_rmsnorm_gated_pallas(x_arr, gate_arr, weight_arr, self.eps)
+            except Exception:
+                if self.use_flash:
+                    raise
+                out_arr = _rmsnorm_gated_reference(x_arr, gate_arr, weight_arr, self.eps)
+        else:
+            out_arr = _rmsnorm_gated_reference(x_arr, gate_arr, weight_arr, self.eps)
+
+        out_perm = out_arr.reshape(x_perm.array.shape)
+        out_named = hax.named(out_perm, permuted_axes)
+        return hax.rearrange(out_named, x.axes)
 
 
 # ---------- Config ----------
@@ -191,6 +303,11 @@ class GatedDeltaNetConfig:
     @property
     def VHeads(self) -> Axis:
         return Axis("v_heads", self.num_v_heads)
+
+    @property
+    def Heads(self) -> Axis:
+        # expose VHeads as heads for tensor-parallel sharding
+        return Axis("heads", self.num_v_heads)
 
     @property
     def KHeadDim(self) -> Axis:
@@ -246,7 +363,7 @@ def _diag_mask(Ci: Axis, Cj: Axis) -> NamedArray:
 # ---------- Kernels ----------
 
 
-def recurrent_gated_delta_rule(
+def _recurrent_gated_delta_rule_reference(
     query: NamedArray,  # [batch, position, heads, k_head_dim]
     key: NamedArray,  # [batch, position, heads, k_head_dim]
     value: NamedArray,  # [batch, position, heads, v_head_dim]
@@ -300,6 +417,7 @@ def recurrent_gated_delta_rule(
     # Prepare initial S
     B_, H_, L_, dk_, dv_ = Batch.size, Heads.size, Pos.size, Dk.size, Dv.size
     S0 = jnp.zeros((B_, H_, dk_, dv_), dtype=v.dtype) if initial_state is None else initial_state.astype(v.dtype)
+    _dbg("recurrent/S0", S0)
 
     # Re-layout to positional major for lax.scan
     q_bhld = hax.rearrange(q, (Batch, Heads, Pos, Dk)).array  # (B,H,L,d_k)
@@ -350,11 +468,224 @@ def recurrent_gated_delta_rule(
     out_bhlv = jnp.moveaxis(out_seq, 0, 2)  # (B,H,L,Dv)
     out_bhlv = hax.named(out_bhlv, (Batch, Heads, Pos, Dv))
     out_final = hax.rearrange(out_bhlv, (Batch, Pos, Heads, Dv))
+    _dbg("recurrent/out", out_final.array)
 
     if output_final_state:
         return out_final, S_final
     else:
         return out_final, None
+
+
+def _recurrent_gated_delta_rule_flash(
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    g: NamedArray,
+    beta: NamedArray,
+    *,
+    initial_state: Optional[jnp.ndarray] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+) -> Tuple[NamedArray, Optional[jnp.ndarray]]:
+    Batch = query.resolve_axis("batch")
+    Pos = query.resolve_axis("position")
+    Heads = query.resolve_axis("heads")
+    Dk = query.resolve_axis("k_head_dim")
+    Dv = value.resolve_axis("v_head_dim")
+
+    q = query.astype(jnp.float32)
+    k = key.astype(jnp.float32)
+    v = value.astype(jnp.float32)
+    gg = g.astype(jnp.float32)
+    b = beta.astype(jnp.float32)
+
+    q_arr = hax.rearrange(q, (Batch, Heads, Pos, Dk)).array
+    k_arr = hax.rearrange(k, (Batch, Heads, Pos, Dk)).array
+    v_arr = hax.rearrange(v, (Batch, Heads, Pos, Dv)).array
+    g_arr = hax.rearrange(gg, (Batch, Heads, Pos)).array
+
+    beta_axis_names = tuple(ax.name for ax in beta.axes)
+    if Dv.name in beta_axis_names:
+        beta_arr = hax.rearrange(b, (Batch, Heads, Pos, Dv)).array
+        is_beta_headwise = False
+    else:
+        beta_arr = hax.rearrange(b, (Batch, Heads, Pos)).array
+        is_beta_headwise = True
+
+    B_, H_, T_, K_ = q_arr.shape
+    V_ = v_arr.shape[-1]
+    NH = B_ * H_
+
+    q_flat = q_arr.reshape(NH, T_, K_)
+    k_flat = k_arr.reshape(NH, T_, K_)
+    v_flat = v_arr.reshape(NH, T_, V_)
+    g_flat = g_arr.reshape(NH, T_)
+    if is_beta_headwise:
+        beta_flat = beta_arr.reshape(NH, T_)
+    else:
+        beta_flat = beta_arr.reshape(NH, T_, V_)
+
+    if initial_state is None:
+        init_state = jnp.zeros((NH, K_, V_), dtype=jnp.float32)
+    else:
+        init_state = initial_state.astype(jnp.float32).reshape(NH, K_, V_)
+
+    def kernel(
+        q_ref,
+        k_ref,
+        v_ref,
+        g_ref,
+        beta_ref,
+        init_ref,
+        out_ref,
+        final_ref,
+        *,
+        T,
+        K,
+        V,
+        use_qk_l2norm,
+        store_final_state,
+        has_initial_state,
+        is_beta_headwise,
+        scale,
+    ):
+        head = pl.program_id(0)
+        q_view = q_ref[dslice(head, 1), dslice(0, T), dslice(0, K)][0]
+        k_view = k_ref[dslice(head, 1), dslice(0, T), dslice(0, K)][0]
+        v_view = v_ref[dslice(head, 1), dslice(0, T), dslice(0, V)][0]
+        g_view = g_ref[dslice(head, 1), dslice(0, T)][0]
+        beta_view = (
+            beta_ref[dslice(head, 1), dslice(0, T)][0]
+            if is_beta_headwise
+            else beta_ref[dslice(head, 1), dslice(0, T), dslice(0, V)][0]
+        )
+        if has_initial_state:
+            state = init_ref[dslice(head, 1), dslice(0, K), dslice(0, V)][0].astype(jnp.float32)
+        else:
+            state = jnp.zeros((K, V), dtype=jnp.float32)
+
+        scale32 = jnp.asarray(scale, dtype=jnp.float32)
+
+        out_tile = jnp.zeros((T, V), dtype=out_ref.dtype)
+        for t in range(T):
+            q_t = q_view[t].astype(jnp.float32)
+            k_t = k_view[t].astype(jnp.float32)
+            if use_qk_l2norm:
+                q_t = q_t / jnp.sqrt(jnp.sum(q_t * q_t) + 1e-6)
+                k_t = k_t / jnp.sqrt(jnp.sum(k_t * k_t) + 1e-6)
+            q_t = q_t * scale32
+            v_t = v_view[t].astype(jnp.float32)
+            g_t = g_view[t].astype(jnp.float32)
+            state = state * jnp.exp(g_t)
+
+            kv = jnp.sum(state * k_t[:, None], axis=0)
+            if is_beta_headwise:
+                beta_t = beta_view[t].astype(jnp.float32)
+                delta = (v_t - kv) * beta_t
+            else:
+                beta_t = beta_view[t].astype(jnp.float32)
+                delta = (v_t - kv) * beta_t
+            state = state + k_t[:, None] * delta[None, :]
+
+            out_tile = out_tile.at[t].set(jnp.sum(state * q_t[:, None], axis=0).astype(out_ref.dtype))
+
+        out_ref[dslice(head, 1), dslice(0, T), dslice(0, V)] = out_tile[None, :, :]
+
+        if store_final_state:
+            final_ref[dslice(head, 1), dslice(0, K), dslice(0, V)] = state.astype(final_ref.dtype)[None, :, :]
+
+    out_struct = jax.ShapeDtypeStruct((NH, T_, V_), v_flat.dtype)
+    final_struct = jax.ShapeDtypeStruct((NH, K_, V_), jnp.float32)
+
+    kernel_partial = functools.partial(
+        kernel,
+        T=T_,
+        K=K_,
+        V=V_,
+        use_qk_l2norm=use_qk_l2norm_in_kernel,
+        store_final_state=output_final_state,
+        has_initial_state=initial_state is not None,
+        is_beta_headwise=is_beta_headwise,
+        scale=Dk.size**-0.5,
+    )
+
+    beta_spec: pl.BlockSpec
+    if is_beta_headwise:
+        beta_spec = pl.BlockSpec((1, T_), lambda bid_nh: (bid_nh, 0))
+    else:
+        beta_spec = pl.BlockSpec((1, T_, V_), lambda bid_nh: (bid_nh, 0, 0))
+
+    result = pl.pallas_call(
+        kernel_partial,
+        out_shape=(out_struct, final_struct),
+        grid=(NH,),
+        in_specs=(
+            pl.BlockSpec((1, T_, K_), lambda bid_nh: (bid_nh, 0, 0)),
+            pl.BlockSpec((1, T_, K_), lambda bid_nh: (bid_nh, 0, 0)),
+            pl.BlockSpec((1, T_, V_), lambda bid_nh: (bid_nh, 0, 0)),
+            pl.BlockSpec((1, T_), lambda bid_nh: (bid_nh, 0)),
+            beta_spec,
+            pl.BlockSpec((1, K_, V_), lambda bid_nh: (bid_nh, 0, 0)),
+        ),
+        out_specs=(
+            pl.BlockSpec((1, T_, V_), lambda bid_nh: (bid_nh, 0, 0)),
+            pl.BlockSpec((1, K_, V_), lambda bid_nh: (bid_nh, 0, 0)),
+        ),
+        interpret=_should_interpret_pallas(),
+    )(q_flat, k_flat, v_flat, g_flat, beta_flat, init_state)
+
+    out_flat, final_flat = result
+    out_arr = out_flat.reshape(B_, H_, T_, V_)
+    out_named = hax.named(out_arr, (Batch, Heads, Pos, Dv))
+    out_final = hax.rearrange(out_named, (Batch, Pos, Heads, Dv))
+
+    if output_final_state:
+        final_arr = final_flat.reshape(B_, H_, K_, V_)
+        return out_final, final_arr
+    else:
+        return out_final, None
+
+
+def recurrent_gated_delta_rule(
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    g: NamedArray,
+    beta: NamedArray,
+    *,
+    initial_state: Optional[jnp.ndarray] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_flash: bool = True,
+) -> Tuple[NamedArray, Optional[jnp.ndarray]]:
+    if use_flash:
+        try:
+            return _recurrent_gated_delta_rule_flash(
+                query,
+                key,
+                value,
+                g,
+                beta,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+        except Exception:
+            if use_flash:
+                raise
+    return _recurrent_gated_delta_rule_reference(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+
+recurrent_gated_delta_rule.__doc__ = _recurrent_gated_delta_rule_reference.__doc__
 
 
 def chunk_gated_delta_rule(
@@ -368,6 +699,7 @@ def chunk_gated_delta_rule(
     initial_state: Optional[jnp.ndarray] = None,  # (B,H,dk,dv)
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = True,
+    use_flash: bool = True,
 ) -> tuple[NamedArray, Optional[jnp.ndarray]]:
     """Chunkwise-parallel GDN (DeltaNet UT/WY extended with decay).
 
@@ -380,6 +712,11 @@ def chunk_gated_delta_rule(
       5) Bridge chunks with the cross-chunk state S (decayed carry and innovation).
       6) Produce outputs by combining inter-chunk (from S) and intra-chunk terms.
     """
+
+    if use_flash:
+        # Flash-optimized chunk kernel will be added in a follow-up change.
+        # For now we intentionally fall back to the reference implementation.
+        pass
     # ---- axes ----
     Batch = query.resolve_axis("batch")
     Pos = query.resolve_axis("position")
@@ -458,6 +795,8 @@ def chunk_gated_delta_rule(
 
     # --- Forward substitution (UT transform) to get T = (I - A)^{-1} ---
     A_bhcc = hax.rearrange(A, (Batch, Heads, Chunks, Ci, Cj)).array
+    _dbg("chunk/A_bhcc", A_bhcc)
+
     eyeC = jnp.eye(C.size, dtype=A_bhcc.dtype)
 
     def body(i, attn):
@@ -483,6 +822,7 @@ def chunk_gated_delta_rule(
 
     attn_low = lax.fori_loop(1, C.size, body, A_bhcc)
     T = attn_low + eyeC  # lower-triangular with ones on diagonal; acts like (I - A)^-1
+    _dbg("chunk/T", T)
 
     # --- Pseudo values and decayed key summaries (intra-chunk) ---
     # v_pseudo = T @ (β V)
@@ -493,6 +833,8 @@ def chunk_gated_delta_rule(
     kbeta_bhccd = hax.rearrange(k_beta.rename({C.name: Cj.name}), (Batch, Heads, Chunks, Cj, Dk)).array
     exp_g_bhcc = hax.rearrange(hax.exp(g_cum).rename({C.name: Cj.name}), (Batch, Heads, Chunks, Cj)).array
     k_cumdecay = jnp.einsum("bhnij,bhnjd->bhnid", T, kbeta_bhccd * exp_g_bhcc[..., None])  # (B,H,Nc,C,d_k)
+    _dbg("chunk/v_pseudo", v_pseudo)
+    _dbg("chunk/k_cumdecay", k_cumdecay)
 
     # --- Scan over chunks: bridge with cross-chunk S ---
     q_bhccd = hax.rearrange(q_c, (Batch, Heads, Chunks, C, Dk)).array
@@ -551,6 +893,7 @@ def chunk_gated_delta_rule(
     out_flat_bhPd = out_bhcd.flatten_axes((Chunks, C), PosPad)
     out_bhLd = out_flat_bhPd["position", hax.ds(0, L)]
     out_final = hax.rearrange(out_bhLd, (Batch, PosPad.name, Heads, Dv))
+    _dbg("chunk/out", out_final.array)
 
     return (out_final, S) if output_final_state else (out_final, None)
 
@@ -590,16 +933,16 @@ class GatedDeltaNet(eqx.Module):
     in_proj_ba: hnn.Linear  # [Embed] -> [b|a]
 
     # depthwise conv parameters over concatenated [Q|K|V] channels
-    conv_weight: jnp.ndarray
-    conv_bias: Optional[jnp.ndarray]
+    conv_weight: NamedArray  # [channels, conv_kernel]
+    conv_bias: Optional[NamedArray]  # [channels] or None
 
     # discretization params per V head (Mamba2-style)
-    A_log: jnp.ndarray
-    dt_bias: jnp.ndarray
+    A_log: NamedArray  # [Heads]
+    dt_bias: NamedArray  # [Heads]
 
     # gated RMSNorm and output projection
-    o_norm: GatedRmsNorm
-    out_proj: hnn.Linear  # [VHeads, VHeadDim] -> [Embed]
+    o_norm: FusedRMSNormGated
+    out_proj: hnn.Linear  # [Heads, VHeadDim] -> [Embed]
 
     @staticmethod
     def init(config: GatedDeltaNetConfig, *, key) -> "GatedDeltaNet":
@@ -624,16 +967,23 @@ class GatedDeltaNet(eqx.Module):
         # Depthwise conv over channels = 2*key_dim + value_dim
         C = config.key_dim * 2 + config.value_dim
         K = config.conv_kernel_size
-        conv_weight = jax.random.normal(k_conv, (C, K), dtype=jnp.float32) * (1.0 / jnp.sqrt(C * K))
+        ConvChannels = Axis("channels", C)
+        ConvKernel = Axis("conv_kernel", K)
+
+        conv_w = jax.random.normal(k_conv, (C, K), dtype=jnp.float32) * (1.0 / jnp.sqrt(C * K))
+        conv_weight = hax.named(conv_w, (ConvChannels, ConvKernel))
         conv_bias = None
 
         # GDN discretization parameters (per V-head)
-        A_log = jnp.log(jax.random.uniform(k_out, (config.num_v_heads,), minval=1e-6, maxval=16.0, dtype=jnp.float32))
-        dt_bias = jnp.ones((config.num_v_heads,), dtype=jnp.float32)
+        A_log = hax.named(
+            jnp.log(jax.random.uniform(k_out, (config.Heads.size,), minval=1e-6, maxval=16.0, dtype=jnp.float32)),
+            (config.Heads.name,),
+        )
+        dt_bias = hax.named(jnp.ones((config.Heads.size,), dtype=jnp.float32), (config.Heads.name,))
 
-        o_norm = GatedRmsNorm.init(config.VHeadDim, eps=config.rms_norm_eps)
+        o_norm = FusedRMSNormGated.init(config.VHeadDim, eps=config.rms_norm_eps)
         out_proj = hnn.Linear.init(
-            In=(config.VHeads, config.VHeadDim), Out=config.Embed, out_first=True, use_bias=False, key=k_out
+            In=(config.Heads, config.VHeadDim), Out=config.Embed, out_first=True, use_bias=False, key=k_out
         )
         return GatedDeltaNet(
             config=config,
@@ -649,7 +999,7 @@ class GatedDeltaNet(eqx.Module):
 
     def _fix_qkvz_ordering(
         self,
-        mixed_qkvz: NamedArray,  # [B, Pos, qkvz]
+        mixed_qkvz: NamedArray,  # [B, Pos, qkvz=2*key_dim + 2*value_dim]
         mixed_ba: NamedArray,  # [B, Pos, 2*num_v_heads]
     ) -> Tuple[NamedArray, NamedArray, NamedArray, NamedArray, NamedArray, NamedArray]:
         """Split packed projections into per-head tensors and align head layout. (match HF version)
@@ -730,9 +1080,13 @@ class GatedDeltaNet(eqx.Module):
             m3 = attention_mask.astype(x.dtype).broadcast_axis(cfg.Embed)
             x = x * m3
 
+        _dbg("layer/in_x", x.array if hasattr(x, "array") else x)
+
         # 1) Project to [Q|K|V|Z] and [b|a]
         mixed_qkvz = self.in_proj_qkvz(x)  # [B, Pos, qkvz=2*key_dim + 2*value_dim]
         mixed_ba = self.in_proj_ba(x)  # [B, Pos, ba=2*num_v_heads]
+        _dbg("layer/mixed_qkvz", mixed_qkvz.array if hasattr(mixed_qkvz, "array") else mixed_qkvz)
+        _dbg("layer/mixed_ba", mixed_ba.array if hasattr(mixed_ba, "array") else mixed_ba)
 
         # 1b) Re-group like HF for parity (also used for conv channel ordering)
         q, k, v, z, b, a = self._fix_qkvz_ordering(mixed_qkvz, mixed_ba)
@@ -744,30 +1098,39 @@ class GatedDeltaNet(eqx.Module):
         v_ch = v.flatten_axes((cfg.VHeads, cfg.VHeadDim), Axis("channels", cfg.value_dim))
         qkv_ch = hax.concatenate("channels", [q_ch, k_ch, v_ch])  # [B, Pos, channels]
         qkv_ncl = hax.rearrange(qkv_ch, ("batch", "channels", "position")).array  # (N, C, L)
+        _dbg("conv/in_ncl", qkv_ncl)
 
         S_state: Optional[jnp.ndarray] = None
         if decode_state is not None and x.axis_size("position") == 1:
             # Streaming decode: cheap single-step conv update + carry conv_state
             conv_state, S_state = decode_state
-            K = self.conv_weight.shape[-1]
+            K = self.conv_weight.resolve_axis("conv_kernel").size
             assert conv_state.shape[-1] == K
+            _dbg("conv/state_in_decode", conv_state)
             y_ncl, new_conv_state = _causal_depthwise_conv1d_update(
-                qkv_ncl, self.conv_weight, self.conv_bias, conv_state
+                qkv_ncl,
+                self.conv_weight.array,
+                self.conv_bias.array if self.conv_bias is not None else None,
+                conv_state,
             )
         else:
             # Prefill/train: full causal conv over the sequence
-            y_ncl = _causal_depthwise_conv1d_full(qkv_ncl, self.conv_weight, self.conv_bias)
+            y_ncl = _causal_depthwise_conv1d_full(
+                qkv_ncl, self.conv_weight.array, self.conv_bias.array if self.conv_bias is not None else None
+            )
             if inference:
                 # cache the rightmost K samples of channels as the next conv_state
-                K = self.conv_weight.shape[-1]
-                L = x.axis_size("position")
-                if L >= K:
+                K = self.conv_weight.resolve_axis("conv_kernel").size
+                Lpos = x.axis_size("position")
+                if Lpos >= K:
                     new_conv_state = qkv_ncl[..., -K:]
                 else:
-                    new_conv_state = jnp.pad(qkv_ncl, ((0, 0), (0, 0), (K - L, 0)))
+                    new_conv_state = jnp.pad(qkv_ncl, ((0, 0), (0, 0), (K - Lpos, 0)))
             else:
                 new_conv_state = None
                 S_state = None
+
+        _dbg("conv/out_ncl", y_ncl)
 
         # Unpack [Q|K|V] after conv back to per-head tensors (mirror the same channel order)
         y_bpc = hax.rearrange(hax.named(y_ncl, ("batch", "channels", "position")), ("batch", "position", "channels"))
@@ -779,37 +1142,48 @@ class GatedDeltaNet(eqx.Module):
         v = v_y.unflatten_axis("channels", (cfg.VHeads, cfg.VHeadDim))
 
         # 3) Gates: β via sigmoid(b); α via g = -exp(A) * softplus(a + dt_bias), α=exp(g)
-        beta = hnn.sigmoid(b)
-        a32 = a.astype(jnp.float32)
-        dt_bias_na = hax.named(jnp.asarray(self.dt_bias, dtype=jnp.float32), cfg.VHeads)
-        A_exp = hax.exp(hax.named(jnp.asarray(self.A_log, dtype=jnp.float32), cfg.VHeads))
-        g = -(A_exp * hnn.softplus(a32 + dt_bias_na)).astype(x.dtype)  # log-decay
-
-        # If we have more V-heads than K-heads, repeat Q,K across V-groups so
-        # every V-head has its own (q,k) and thus its own rectangular S.
+        # Map a, b to Heads axis to line up with TP and kernels.
         ratio = cfg.num_v_heads // cfg.num_k_heads
         if ratio > 1:
             VGroup = Axis("v_group", ratio)
-            q = q.broadcast_axis(VGroup).flatten_axes((cfg.KHeads, VGroup), cfg.VHeads)
-            k = k.broadcast_axis(VGroup).flatten_axes((cfg.KHeads, VGroup), cfg.VHeads)
+            # Repeat Q,K to Heads (num_v_heads)
+            q = q.broadcast_axis(VGroup).flatten_axes((cfg.KHeads, VGroup), cfg.Heads)
+            k = k.broadcast_axis(VGroup).flatten_axes((cfg.KHeads, VGroup), cfg.Heads)
+            # Map V/Z/B/A to Heads as well
+            v_h = v.rename({cfg.VHeads.name: cfg.Heads.name})
+            z_h = z.rename({cfg.VHeads.name: cfg.Heads.name})
+            b_hparam = b.rename({cfg.VHeads.name: cfg.Heads.name})
+            a_hparam = a.rename({cfg.VHeads.name: cfg.Heads.name})
         else:
-            q = q.rename({cfg.KHeads.name: cfg.VHeads.name})
-            k = k.rename({cfg.KHeads.name: cfg.VHeads.name})
+            # 1:1 map KHeads -> Heads; and VHeads -> Heads for v/z/a/b
+            q = q.rename({cfg.KHeads.name: cfg.Heads.name})
+            k = k.rename({cfg.KHeads.name: cfg.Heads.name})
+            v_h = v.rename({cfg.VHeads.name: cfg.Heads.name})
+            z_h = z.rename({cfg.VHeads.name: cfg.Heads.name})
+            b_hparam = b.rename({cfg.VHeads.name: cfg.Heads.name})
+            a_hparam = a.rename({cfg.VHeads.name: cfg.Heads.name})
 
-        # 4) Kernels expect [batch, position, heads, dim] with axis name "heads"
-        q_h = q.rename({cfg.VHeads.name: "heads"})
-        k_h = k.rename({cfg.VHeads.name: "heads"})
-        v_h = v.rename({cfg.VHeads.name: "heads"})
-        g_h = g.rename({cfg.VHeads.name: "heads"})
-        b_h = beta.rename({cfg.VHeads.name: "heads"})
+        beta = hnn.sigmoid(b_hparam)
+        a32 = a_hparam.astype(jnp.float32)
+        dt_bias_na = self.dt_bias.astype(jnp.float32)
+        A_exp = hax.exp(self.A_log.astype(jnp.float32))
+        g = -(A_exp * hnn.softplus(a32 + dt_bias_na)).astype(x.dtype)  # log-decay on Heads
+
+        # 4) Kernels expect [batch, position, heads, dim] (axis name "heads")
+        q_h = q.rename({cfg.Heads.name: "heads"})
+        k_h = k.rename({cfg.Heads.name: "heads"})
+        v_kern = v_h.rename({cfg.Heads.name: "heads"})
+        g_h = g.rename({cfg.Heads.name: "heads"})
+        b_h = beta.rename({cfg.Heads.name: "heads"})
 
         q_bphd = hax.rearrange(q_h, ("batch", "position", "heads", cfg.KHeadDim.name))
         k_bphd = hax.rearrange(k_h, ("batch", "position", "heads", cfg.KHeadDim.name))
-        v_bphd = hax.rearrange(v_h, ("batch", "position", "heads", cfg.VHeadDim.name))
+        v_bphd = hax.rearrange(v_kern, ("batch", "position", "heads", cfg.VHeadDim.name))
+        _dbg("kernel/q_bphd", q_bphd.array)
+        _dbg("kernel/k_bphd", k_bphd.array)
+        _dbg("kernel/v_bphd", v_bphd.array)
 
         # Choose the kernel:
-        #  - decode (1 token, with state): recurrent rule
-        #  - else: chunkwise-parallel rule
         if decode_state is not None and x.axis_size("position") == 1 and S_state is not None:
             out_bphd, S_new = recurrent_gated_delta_rule(
                 q_bphd,
@@ -829,19 +1203,22 @@ class GatedDeltaNet(eqx.Module):
                 g_h,
                 b_h,
                 chunk_size=chunk_size,
-                initial_state=None,  # could feed S_state if continuing
-                output_final_state=inference,  # return S_T for caching if inference
+                initial_state=None,
+                output_final_state=inference,
                 use_qk_l2norm_in_kernel=True,
             )
 
-        # Back to [B, Pos, VHeads, VHeadDim]
-        out = out_bphd.rename({"heads": cfg.VHeads.name})
+        # Keep the kernel output on "heads" so TP can shard the out-projection.
+        out = out_bphd  # [B, Pos, heads, VHeadDim]
+        _dbg("kernel/out_bphd", out.array)
 
-        # 5) Gated RMSNorm with Z (GDN block’s output gate)
-        y_norm = self.o_norm(out, gate=z)
+        # 5) Gated RMSNorm with Z (rename Z to "heads" to match)
+        z_gate = z_h.rename({cfg.Heads.name: "heads"})
+        y_norm = self.o_norm(out, gate=z_gate)
 
-        # 6) Output projection back to model dimension
+        # 6) Output projection back to model dimension (In=(Heads, VHeadDim) -> Out=Embed)
         y_out = self.out_proj(y_norm.astype(x.dtype))
+        _dbg("layer/y_out", y_out.array)
 
         # State packing for streaming
         new_state: Optional[Tuple[jnp.ndarray, jnp.ndarray]] = None
@@ -853,9 +1230,9 @@ class GatedDeltaNet(eqx.Module):
         return {
             "in_proj_qkvz.weight": jnp.array(self.in_proj_qkvz.weight.array),
             "in_proj_ba.weight": jnp.array(self.in_proj_ba.weight.array),
-            "conv_weight": jnp.array(self.conv_weight),
-            "A_log": jnp.array(self.A_log),
-            "dt_bias": jnp.array(self.dt_bias),
+            "conv_weight": jnp.array(self.conv_weight.array),
+            "A_log": jnp.array(self.A_log.array),
+            "dt_bias": jnp.array(self.dt_bias.array),
             "o_norm.weight": jnp.array(self.o_norm.weight.array),
             "out_proj.weight": jnp.array(self.out_proj.weight.array),
         }
@@ -871,15 +1248,23 @@ class GatedDeltaNet(eqx.Module):
             self.in_proj_qkvz, state["in_proj_qkvz.weight"], cfg.mix_qkvz_axis, cfg.Embed
         )
         new_in_proj_ba = _assign_linear_weight(self.in_proj_ba, state["in_proj_ba.weight"], cfg.ba_axis, cfg.Embed)
-        new_conv_weight = jnp.asarray(state["conv_weight"], dtype=jnp.float32)
-        new_A_log = jnp.asarray(state["A_log"], dtype=jnp.float32)
-        new_dt_bias = jnp.asarray(state["dt_bias"], dtype=jnp.float32)
+
+        # Rebuild named conv axes
+        ConvChannels = Axis("channels", cfg.key_dim * 2 + cfg.value_dim)
+        ConvKernel = Axis("conv_kernel", cfg.conv_kernel_size)
+        new_conv_weight = hax.named(jnp.asarray(state["conv_weight"], dtype=jnp.float32), (ConvChannels, ConvKernel))
+
+        # Heads-based params
+        new_A_log = hax.named(jnp.asarray(state["A_log"], dtype=jnp.float32), (cfg.Heads.name,))
+        new_dt_bias = hax.named(jnp.asarray(state["dt_bias"], dtype=jnp.float32), (cfg.Heads.name,))
         new_o_norm = dataclasses.replace(
             self.o_norm, weight=hax.named(jnp.asarray(state["o_norm.weight"], dtype=jnp.float32), (cfg.VHeadDim.name,))
         )
-        out_w = jnp.asarray(state["out_proj.weight"], dtype=jnp.float32)  # (embed, v_heads, v_head_dim)
+
+        # out_proj.weight is (Embed, Heads, VHeadDim)
+        out_w = jnp.asarray(state["out_proj.weight"], dtype=jnp.float32)
         new_out_proj = dataclasses.replace(
-            self.out_proj, weight=hax.named(out_w, (cfg.Embed.name, cfg.VHeads.name, cfg.VHeadDim.name))
+            self.out_proj, weight=hax.named(out_w, (cfg.Embed.name, cfg.Heads.name, cfg.VHeadDim.name))
         )
 
         return dataclasses.replace(
@@ -895,8 +1280,5 @@ class GatedDeltaNet(eqx.Module):
 
     @classmethod
     def from_state_dict(cls, config: GatedDeltaNetConfig, state: dict[str, jnp.ndarray], *, key) -> "GatedDeltaNet":
-        """
-        Build a fresh layer from config + state dict.
-        """
         layer = cls.init(config, key=key)
         return layer.load_state_dict(state)

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -1694,6 +1694,8 @@ def _gdn_chunk_bwd_kernel_fused(
     g_c = g_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)  # [C]
     b_c = beta_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)  # [C]
     A0 = a0_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, C)][0].astype(jnp.float32)  # [C, C]
+    # Ensure A0 is finite to prevent propagation of NaNs from any undefined tiles
+    A0 = jnp.nan_to_num(A0)
     S_prev = s_prev_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)  # [K, BV]
     dY = dout_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)  # [C, BV]
     dS_in = dS_in_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)  # [K, BV]
@@ -1967,6 +1969,19 @@ def _gdn_chunk_bwd_kernel_fused(
 
     # S_prev: local (inter + v_new path) + carry α_tail
     dS_out = (dS_prev_local + alpha_tail * dS_in).astype(jnp.float32)
+
+    # Final numerical safety: replace any NaNs/infs with zeros to ensure finite grads
+    dQ_attn = jnp.nan_to_num(dQ_attn)
+    dQ_inter = jnp.nan_to_num(dQ_inter)
+    dK_attn = jnp.nan_to_num(dK_attn)
+    dK_rhs = jnp.nan_to_num(dK_rhs)
+    dK_from_A0 = jnp.nan_to_num(dK_from_A0)
+    dK_add = jnp.nan_to_num(dK_add)
+    dK_tile = jnp.nan_to_num(dK_tile)
+    dV_tile = jnp.nan_to_num(dV_tile)
+    dG_tile = jnp.nan_to_num(dG_tile)
+    dB_tile = jnp.nan_to_num(dB_tile)
+    dS_out = jnp.nan_to_num(dS_out)
 
     # dV tile already masked above; ensure dtype matches out ref
     dV_tile = dV_tile * m[:, None]

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -1290,6 +1290,9 @@ def _chunk_gated_delta_rule_reference(
     return (out_final, S) if output_final_state else (out_final, None)
 
 
+# ---------- fused forward (chunk) kernel (Pallas) ----------
+
+
 def _gdn_chunk_fwd_kernel_fused(
     q_ref,  # [NH, T_pad, K]
     k_ref,  # [NH, T_pad, K]
@@ -1298,10 +1301,10 @@ def _gdn_chunk_fwd_kernel_fused(
     beta_ref,  # [NH, T_pad]
     s_prev_ref,  # [NH, K, BV]
     ci_ref,  # [1]  int32 (chunk index)
-    lengths_ref,  # [NH] int32 (per sequence length)
+    lengths_ref,  # [NH] int32
     out_tile_ref,  # [NH, 1, C, BV]
     s_tile_ref,  # [NH, 1, K, BV]
-    a0_tile_ref,  # [NH, 1, C, C]
+    a0_tile_ref,  # [NH, 1, C, C]  (written only by vt==0)
     *,
     T_pad: int,
     K: int,
@@ -1311,23 +1314,23 @@ def _gdn_chunk_fwd_kernel_fused(
     BV: int,
 ):
     nh = pl.program_id(0)
-    vt = pl.program_id(1)
+    vt = pl.program_id(1)  # value tile id
 
-    # --- chunk index / active rows
     ci = ci_ref[dslice(0, 1)][0].astype(jnp.int32)
     c0 = ci * jnp.int32(chunk_len)
-    Lnh = lengths_ref[dslice(nh, 1)][0].astype(jnp.int32)
-    active = jnp.clip(Lnh - c0, 0, jnp.int32(chunk_len))
-    ar = lax.iota(jnp.int32, chunk_len)
-    m = (ar < active).astype(jnp.float32)  # (C,)
 
-    # --- read chunk views
+    Lnh = lengths_ref[dslice(nh, 1)][0].astype(jnp.int32)
+    active = jnp.clip(Lnh - c0, 0, jnp.int32(chunk_len))  # number of valid rows in this chunk
+    ar = lax.iota(jnp.int32, chunk_len)
+    m = (ar < active).astype(jnp.float32)  # row mask (C,)
+
+    # chunk views
     q_c = q_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)
     k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)
-    v_c = v_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(v0 := vt * jnp.int32(BV), BV)][0].astype(jnp.float32)
+    v_c = v_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(vt * jnp.int32(BV), BV)][0].astype(jnp.float32)
     g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
     b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
-    S_prev_v = s_prev_ref[dslice(nh, 1), dslice(0, K), dslice(v0, BV)][0].astype(jnp.float32)
+    S_prev_v = s_prev_ref[dslice(nh, 1), dslice(0, K), dslice(vt * jnp.int32(BV), BV)][0].astype(jnp.float32)
 
     # mask inactive rows
     q_c = q_c * m[:, None]
@@ -1335,7 +1338,7 @@ def _gdn_chunk_fwd_kernel_fused(
     v_c = v_c * m[:, None]
     b_c = b_c * m
 
-    # cumulative g, tail, exp(g)
+    # cumulative g and tail
     g_cum = jnp.cumsum(g_c, axis=0)
     eg = jnp.exp(g_cum)
     g_tail = lax.cond(
@@ -1346,119 +1349,122 @@ def _gdn_chunk_fwd_kernel_fused(
     )
     alpha_tail = jnp.exp(g_tail)
 
-    # ---------- Gram and A0 (strictly lower) ----------
-    G = jnp.zeros((chunk_len, chunk_len), dtype=jnp.float32)
+    # Gram and strictly-lower A0 (no decays here)
     n_kb = (K + BK - 1) // BK
+    G = jnp.zeros((chunk_len, chunk_len), jnp.float32)
 
     def gram_body(kb, G_cur):
         k0 = kb * BK
-        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
-        kb_tile = k_tile * b_c[:, None]  # βK
-        return G_cur + kb_tile @ jnp.transpose(k_tile)
+        kt = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
+        kb_t = kt * b_c[:, None]  # βK
+        return G_cur + kb_t @ jnp.transpose(kt)
 
     G = lax.fori_loop(0, n_kb, gram_body, G)
-    A0 = -jnp.tril(G, k=-1)  # (C, C)
+    A0 = -jnp.tril(G, k=-1)  # strictly lower
 
-    # write A0 once per (NH, chunk) – only vt==0 writes
+    # write A0 once (vt==0)
     def _write_a0(_):
         a0_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, chunk_len), dslice(0, chunk_len)] = A0[None, None, :, :]
         return ()
 
     _ = lax.cond(vt == 0, _write_a0, lambda _: (), operand=None)
 
-    # ---------- forward-sub yv (C×BV) ----------
-    yv_tile = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
+    # forward-sub for yv (C×BV):  yv = T (β v)
+    yv = jnp.zeros((chunk_len, BV), jnp.float32)
 
     def fs_v(i, Y):
         rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]
 
-        def acc_v(j, acc):
+        def acc_j(j, acc):
             aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-            decay = jnp.exp(g_cum[i] - g_cum[j])
+            decay = jnp.exp(g_cum[i] - g_cum[j])  # relative decay
             yj = lax.dynamic_slice(Y, (j, 0), (1, BV))[0]
             return acc + (aij * decay) * yj
 
-        contrib = lax.fori_loop(0, i, acc_v, jnp.zeros((BV,), dtype=jnp.float32))
+        contrib = lax.fori_loop(0, i, acc_j, jnp.zeros((BV,), jnp.float32))
         yi = rhs_i + contrib
         return lax.dynamic_update_slice(Y, yi[None, :], (i, 0))
 
-    yv_tile = lax.fori_loop(0, active, fs_v, yv_tile)
+    yv = lax.fori_loop(0, active, fs_v, yv)
 
-    # ---------- forward-sub yk (C×K) in BK tiles ----------
-    yk_tile = jnp.zeros((chunk_len, K), dtype=jnp.float32)
+    # forward-sub for yk (C×K) in BK tiles:  yk = T (β k ⊙ exp(g_cum))
+    yk = jnp.zeros((chunk_len, K), jnp.float32)
 
     def fs_k(kb, Y):
         k0 = kb * BK
-        k_t = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
-        rhs_tile = (eg[:, None] * (b_c[:, None] * k_t)).astype(jnp.float32)
+        kt = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
+        rhs_tile = eg[:, None] * (b_c[:, None] * kt)
 
         def fs_row(i, Ycur):
             rhs_i = lax.dynamic_slice(rhs_tile, (i, 0), (1, BK))[0]
 
-            def acc_k(j, acc):
+            def acc_j(j, acc):
                 aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
                 decay = jnp.exp(g_cum[i] - g_cum[j])
                 yj = lax.dynamic_slice(Ycur, (j, k0), (1, BK))[0]
                 return acc + (aij * decay) * yj
 
-            contrib = lax.fori_loop(0, i, acc_k, jnp.zeros((BK,), dtype=jnp.float32))
+            contrib = lax.fori_loop(0, i, acc_j, jnp.zeros((BK,), jnp.float32))
             yi = rhs_i + contrib
             return lax.dynamic_update_slice(Ycur, yi[None, :], (i, k0))
 
         return lax.fori_loop(0, active, fs_row, Y)
 
-    yk_tile = lax.fori_loop(0, n_kb, fs_k, yk_tile)
+    yk = lax.fori_loop(0, n_kb, fs_k, yk)
 
-    # ---------- pass 1 accumulators ----------
-    v_prime = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
-    inter = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
-    qk_raw = jnp.zeros((chunk_len, chunk_len), dtype=jnp.float32)
+    # pass 1 accumulators for (inter, v_prime) and qk
+    v_prime = jnp.zeros((chunk_len, BV), jnp.float32)
+    inter = jnp.zeros((chunk_len, BV), jnp.float32)
+    qk_raw = jnp.zeros((chunk_len, chunk_len), jnp.float32)
 
-    def pass1_body(kb, acc):
+    def pass1(kb, acc):
         vpr_acc, inter_acc, qk_acc = acc
         k0 = kb * BK
-        q_tile = lax.dynamic_slice(q_c, (0, k0), (chunk_len, BK))
-        yk_t = lax.dynamic_slice(yk_tile, (0, k0), (chunk_len, BK))
+        q_t = lax.dynamic_slice(q_c, (0, k0), (chunk_len, BK))
+        yk_t = lax.dynamic_slice(yk, (0, k0), (chunk_len, BK))
         S_blk = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))
         vpr_acc = vpr_acc + yk_t @ S_blk
-        inter_acc = inter_acc + (q_tile * eg[:, None]) @ S_blk
-        qk_acc = qk_acc + q_tile @ jnp.transpose(lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK)))
+        inter_acc = inter_acc + (q_t * eg[:, None]) @ S_blk
+        qk_acc = qk_acc + q_t @ jnp.transpose(lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK)))
         return (vpr_acc, inter_acc, qk_acc)
 
-    v_prime, inter, qk_raw = lax.fori_loop(0, n_kb, pass1_body, (v_prime, inter, qk_raw))
+    v_prime, inter, qk_raw = lax.fori_loop(0, n_kb, pass1, (v_prime, inter, qk_raw))
 
     decay = jnp.exp(g_cum[:, None] - g_cum[None, :])
     attn = jnp.tril(decay * qk_raw)
 
-    v_new = yv_tile - v_prime
+    v_new = yv - v_prime
     out = inter + attn @ v_new
 
-    # ---------- state update ----------
-    dw = jnp.exp(g_tail - g_cum) * m
-    v_weighted = v_new * dw[:, None]
-    S_add = jnp.zeros((K, BV), dtype=jnp.float32)
+    # state update
+    w = jnp.exp(g_tail - g_cum) * m
+    v_w = v_new * w[:, None]
+    S_add = jnp.zeros((K, BV), jnp.float32)
 
-    def body_kb(kb, S_acc):
+    def add_kb(kb, S_acc):
         k0 = kb * BK
-        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
-        S_add_tile = jnp.transpose(k_tile) @ v_weighted
-        return lax.dynamic_update_slice(S_acc, S_add_tile, (k0, 0))
+        kt = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
+        return lax.dynamic_update_slice(S_acc, jnp.transpose(kt) @ v_w, (k0, 0))
 
-    S_add = lax.fori_loop(0, n_kb, body_kb, S_add)
+    S_add = lax.fori_loop(0, n_kb, add_kb, S_add)
 
-    def write_s(kb, _):
+    def write_kb(kb, _):
         k0 = kb * BK
         S_blk = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))
         S_new_blk = alpha_tail * S_blk + lax.dynamic_slice(S_add, (k0, 0), (BK, BV))
         s_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(k0, BK), dslice(0, BV)] = S_new_blk[None, None, :, :]
         return ()
 
-    _ = lax.fori_loop(0, n_kb, write_s, ())
+    _ = lax.fori_loop(0, n_kb, write_kb, ())
 
-    # write output tile
+    # write output tile (mask inactive rows)
+    out = out * m[:, None]
     out_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, chunk_len), dslice(0, BV)] = out.astype(out_tile_ref.dtype)[
         None, None, :, :
     ]
+
+
+# ---------- fused forward (chunk) launcher ----------
 
 
 def _chunk_gated_delta_rule_flash_fused(
@@ -1478,7 +1484,7 @@ def _chunk_gated_delta_rule_flash_fused(
     use_varlen: bool = False,
     save_for_backward: bool = False,
 ):
-    # ----- (unchanged) layout/flatten/pad/QK-norm -----
+    # (unchanged layout/flatten/pad/L2norm; kept here for completeness)
     if head_first:
         B, H, L, K = query.shape[:4]
         V = value.shape[-1]
@@ -1543,21 +1549,19 @@ def _chunk_gated_delta_rule_flash_fused(
     if V_pad != V:
         v_flat = jnp.pad(v_flat, ((0, 0), (0, 0), (0, V_pad - V)))
 
-    # Initial S (NH,K,V_pad)
     if initial_state is None:
-        S = jnp.zeros((NH, K, V_pad), dtype=jnp.float32)
+        S = jnp.zeros((NH, K, V_pad), jnp.float32)
     else:
         init = initial_state.astype(jnp.float32)
         S = init.reshape(NH, K, init.shape[-1]) if init.ndim == 4 else init
         if S.shape[-1] != V_pad:
             S = jnp.pad(S, ((0, 0), (0, 0), (0, V_pad - S.shape[-1])))
 
-    out_pad = jnp.zeros((NH, T_pad, V_pad), dtype=value.dtype)
+    out_pad = jnp.zeros((NH, T_pad, V_pad), value.dtype)
     n_vtiles = V_pad // BV
 
-    # Buffers for backward
-    A0_buf = jnp.zeros((NH, Nc, C, C), dtype=jnp.float32) if save_for_backward else None
-    S_prev_buf = jnp.zeros((NH, Nc, K, V_pad), dtype=jnp.float32) if save_for_backward else None
+    A0_buf = jnp.zeros((NH, Nc, C, C), jnp.float32) if save_for_backward else None
+    S_prev_buf = jnp.zeros((NH, Nc, K, V_pad), jnp.float32) if save_for_backward else None
 
     kernel = functools.partial(
         _gdn_chunk_fwd_kernel_fused,
@@ -1576,21 +1580,20 @@ def _chunk_gated_delta_rule_flash_fused(
         pl.BlockSpec((1, T_pad), lambda nh, vt: (nh, 0)),  # g
         pl.BlockSpec((1, T_pad), lambda nh, vt: (nh, 0)),  # beta
         pl.BlockSpec((1, K, BV), lambda nh, vt: (nh, 0, vt * BV)),  # S_prev tile
-        pl.BlockSpec((1,), lambda nh, vt: (0,)),  # ci (scalar)
+        pl.BlockSpec((1,), lambda nh, vt: (0,)),  # ci scalar
         pl.BlockSpec((1,), lambda nh, vt: (nh,)),  # lengths[nh]
     )
     out_specs = (
         pl.BlockSpec((1, 1, C, BV), lambda nh, vt: (nh, vt, 0, 0)),  # out tile
         pl.BlockSpec((1, 1, K, BV), lambda nh, vt: (nh, vt, 0, 0)),  # S tile
-        pl.BlockSpec((1, 1, C, C), lambda nh, vt: (nh, 0, 0, 0)),  # A0 tile (vt ignored; only vt==0 writes)
+        pl.BlockSpec((1, 1, C, C), lambda nh, vt: (nh, 0, 0, 0)),  # A0 tile (vt==0 writes)
     )
 
     def one_chunk(carry, ci):
         S_in, out_buf, A0_b, Sprev_b = carry
-        ci_ary = jnp.asarray([ci], dtype=jnp.int32)
+        ci_ary = jnp.asarray([ci], jnp.int32)
 
         if save_for_backward:
-            # Save S_prev (whole V_pad) for this chunk (outside kernel; no tracers in index maps)
             Sprev_b = Sprev_b.at[:, ci, :, :].set(S_in)
 
         with _fp32_mm():
@@ -1611,13 +1614,11 @@ def _chunk_gated_delta_rule_flash_fused(
         s_chunk = s_tiles.reshape(NH, K, n_vtiles * BV)[:, :, :V_pad]
 
         if save_for_backward:
-            # Store A0 for this chunk (written only in vt==0)
             A0_b = A0_b.at[:, ci, :, :].set(a0_tiles[:, 0, :, :])
 
         c0 = ci * C
         out_buf = lax.dynamic_update_slice(out_buf, out_chunk.astype(out_buf.dtype), (0, c0, 0))
-        S_out = s_chunk
-        return (S_out, out_buf, A0_b, Sprev_b), None
+        return (s_chunk, out_buf, A0_b, Sprev_b), None
 
     (S_final, out_all, A0_buf, S_prev_buf), _ = lax.scan(
         one_chunk,
@@ -1630,7 +1631,6 @@ def _chunk_gated_delta_rule_flash_fused(
     out_named = out_bHLv if head_first else jnp.transpose(out_bHLv, (0, 2, 1, 3))
     S_ret = None if not output_final_state else S_final[:, :, :V].reshape(B, H, K, V)
 
-    # Return aux for backward
     aux = (
         {
             "A0_buf": A0_buf,
@@ -1645,8 +1645,11 @@ def _chunk_gated_delta_rule_flash_fused(
         if save_for_backward
         else None
     )
-
     return out_named, S_ret, aux
+
+
+# ---------- fused backward (chunk) kernel (Pallas) ----------
+# NOTE: returns *two* dQ contributions: dQ_attn and dQ_inter (to map L2-bwd separately)
 
 
 def _gdn_chunk_bwd_kernel_fused(
@@ -1660,7 +1663,8 @@ def _gdn_chunk_bwd_kernel_fused(
     dout_tile_ref,  # [NH, C, BV]
     dS_in_tile_ref,  # [NH, K, BV]
     lengths_chunk_ref,  # [NH]
-    dQ_chunk_ref,  # [NH, 1, C, K]
+    dQ_attn_chunk_ref,  # [NH, 1, C, K]
+    dQ_inter_chunk_ref,  # [NH, 1, C, K]
     dK_chunk_ref,  # [NH, 1, C, K]
     dV_tile_ref,  # [NH, 1, C, BV]
     dG_chunk_ref,  # [NH, 1, C]
@@ -1671,43 +1675,55 @@ def _gdn_chunk_bwd_kernel_fused(
     K: int,
     BV: int,
 ):
+    # -------------------------------------------------------------------------
+    # One NH program instance
+    # -------------------------------------------------------------------------
     nh = pl.program_id(0)
 
-    # ---- local views (all dynamic slicing, static sizes) ----
-    q_c = q_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, K)][0].astype(jnp.float32)
-    k_c = k_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, K)][0].astype(jnp.float32)
-    v_c = v_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)
-    g_c = g_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)
-    b_c = beta_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)
-    A0 = a0_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, C)][0].astype(jnp.float32)
-    S_prev = s_prev_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)
-    dY = dout_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)
-    dS_in = dS_in_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)
-    active = jnp.clip(lengths_chunk_ref[dslice(nh, 1)][0].astype(jnp.int32), 0, jnp.int32(C))
+    # -------------------------------------------------------------------------
+    # Slices (local views) and type promotion
+    # -------------------------------------------------------------------------
+    q_c = q_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, K)][0].astype(jnp.float32)  # [C, K]
+    k_c = k_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, K)][0].astype(jnp.float32)  # [C, K]
+    v_c = v_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)  # [C, BV]
+    g_c = g_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)  # [C]
+    b_c = beta_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)  # [C]
+    A0 = a0_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, C)][0].astype(jnp.float32)  # [C, C]
+    S_prev = s_prev_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)  # [K, BV]
+    dY = dout_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)  # [C, BV]
+    dS_in = dS_in_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)  # [K, BV]
 
-    # row mask for varlen chunk
-    m = (lax.iota(jnp.int32, C) < active).astype(jnp.float32)
+    active = jnp.clip(lengths_chunk_ref[dslice(nh, 1)][0].astype(jnp.int32), 0, jnp.int32(C))
+    m = (lax.iota(jnp.int32, C) < active).astype(jnp.float32)  # [C]
+
+    # Mask invalid rows early (dY masked too safeguards reductions)
     q_c = q_c * m[:, None]
     k_c = k_c * m[:, None]
     v_c = v_c * m[:, None]
     b_c = b_c * m
+    dY = dY * m[:, None]
 
-    g_cum = jnp.cumsum(g_c, axis=0)
-    eg = jnp.exp(g_cum)
+    # Cumulated log‑decay and tail scalars
+    g_cum = jnp.cumsum(g_c, axis=0)  # [C]
+    eg = jnp.exp(g_cum)  # [C]
     g_tail = lax.cond(
         active > 0,
         lambda _: lax.dynamic_slice_in_dim(g_cum, active - 1, 1, axis=0)[0],
         lambda _: jnp.array(0.0, jnp.float32),
         operand=None,
     )
-    alpha_tail = jnp.exp(g_tail)
+    alpha_tail = jnp.exp(g_tail)  # scalar
 
-    # ---------- Re-solve yv, yk using saved A0 (forward-sub, bounded by active) ----------
+    # -------------------------------------------------------------------------
+    # Forward‑substitution re‑solve (bounded by 'active'): yv, yk
+    # yv = T (β v)       ∈ ℝ^{C×BV}
+    # yk = T (eg * β k)  ∈ ℝ^{C×K}
+    # -------------------------------------------------------------------------
     def fs_yv():
         Y = jnp.zeros((C, BV), jnp.float32)
 
         def row(i, Ycur):
-            rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]
+            rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]  # [BV]
 
             def acc_j(j, acc):
                 aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
@@ -1721,13 +1737,11 @@ def _gdn_chunk_bwd_kernel_fused(
 
         return lax.fori_loop(0, active, row, Y)
 
-    yv = fs_yv()
-
     def fs_yk():
         Y = jnp.zeros((C, K), jnp.float32)
 
         def row(i, Ycur):
-            rhs_i = (eg[i] * b_c[i]) * lax.dynamic_slice(k_c, (i, 0), (1, K))[0]
+            rhs_i = (eg[i] * b_c[i]) * lax.dynamic_slice(k_c, (i, 0), (1, K))[0]  # [K]
 
             def acc_j(j, acc):
                 aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
@@ -1741,84 +1755,84 @@ def _gdn_chunk_bwd_kernel_fused(
 
         return lax.fori_loop(0, active, row, Y)
 
-    yk = fs_yk()
+    yv = fs_yv()  # [C, BV]
+    yk = fs_yk()  # [C, K]
+    v_prime = yk @ S_prev  # [C, BV]
+    v_new = yv - v_prime  # [C, BV]
 
-    v_prime = yk @ S_prev
-    v_new = yv - v_prime
+    # -------------------------------------------------------------------------
+    # Attn + Inter compositions (parity with Q already verified)
+    # -------------------------------------------------------------------------
+    qk = q_c @ jnp.transpose(k_c)  # [C, C]
+    decay = jnp.exp(g_cum[:, None] - g_cum[None, :])  # [C, C]
+    tril = jnp.tril(jnp.ones((C, C), jnp.float32))  # [C, C]
+    M = decay * tril  # [C, C]
 
-    qk = q_c @ jnp.transpose(k_c)
-    decay = jnp.exp(g_cum[:, None] - g_cum[None, :])
-    tril_mask = jnp.tril(jnp.ones((C, C), jnp.float32))
-    M = decay * tril_mask
-    attn = M * qk
-    # inter = (q_c * eg[:, None]) @ S_prev
+    # dAttn = dY @ v_new^T
+    dAttn = dY @ jnp.transpose(v_new)  # [C, C]
+    d_qk = M * dAttn  # [C, C]
+    dQ_attn = d_qk @ k_c  # [C, K]
+    dK_attn = jnp.transpose(d_qk) @ q_c  # [C, K]
 
-    # ---------- Backprop ----------
-    # out = inter + attn @ v_new
-    dQ_inter = (dY @ jnp.transpose(S_prev)) * eg[:, None]
-    dS_prev_local = jnp.transpose(q_c * eg[:, None]) @ dY
-    inner = jnp.sum((dY @ jnp.transpose(S_prev)) * q_c, axis=-1)
-    dgc_inter = inner * eg
+    # d g from attn (via decay inside M)
+    W = (qk * dAttn) * decay * tril  # [C, C]
+    dgc_attn = jnp.sum(W, axis=1) - jnp.sum(W, axis=0)  # [C]
 
-    dAttn = dY @ jnp.transpose(v_new)
-    dv_new = jnp.transpose(attn) @ dY
-    d_qk = M * dAttn
-    dQ_attn = d_qk @ k_c
-    dK_attn = jnp.transpose(d_qk) @ q_c
-    W = (qk * dAttn) * tril_mask
-    dgc_attn = jnp.sum(W, axis=1) - jnp.sum(W, axis=0)
+    # Inter term
+    dQ_inter = (dY @ jnp.transpose(S_prev)) * eg[:, None]  # [C, K]
+    dS_prev_local = jnp.transpose(q_c * eg[:, None]) @ dY  # [K, BV]
 
-    # v_new = yv - yk @ S_prev
-    dyv = dv_new
-    dyk = -(dv_new @ jnp.transpose(S_prev))
-    dS_prev_local = dS_prev_local - jnp.transpose(yk) @ dv_new
+    # -------------------------------------------------------------------------
+    # v_new path
+    #   dv_new_out   = attn^T @ dY                       (from out = attn @ v_new)
+    #   dv_new_carry = (k @ dS_in) ⊙ w                   (from S_out carry term)
+    #   dyv = dv_new_out + dv_new_carry
+    #   dyk = -(dv_new_out + dv_new_carry) @ S_prev^T
+    #   dS_prev_local -= yk^T @ (dv_new_out + dv_new_carry)
+    # -------------------------------------------------------------------------
+    attn = M * qk  # [C, C]
+    dv_new_out = jnp.transpose(attn) @ dY  # [C, BV]
 
-    # cross-chunk carry: S_out = alpha_tail * S_prev + sum_i (exp(g_tail - g_cum[i]) k_i v_new[i]^T)
-    w = jnp.exp(g_tail - g_cum) * m  # (C,)
-    kv_dS = k_c @ dS_in  # (C, BV)
-    dv_new = dv_new + kv_dS * w[:, None]  # (C, BV)
+    w = jnp.exp(g_tail - g_cum) * m  # [C]
+    kv_dS = k_c @ dS_in  # [C, BV]
+    dv_new_carry = kv_dS * w[:, None]  # [C, BV]
 
-    # dK from carry: for each row i, dK_i += w_i * (dS_in @ v_new_i)
-    dK_add = ((dS_in @ jnp.transpose(v_new)).T) * w[:, None]  # (C, K)
+    dv_new_total = dv_new_out + dv_new_carry  # [C, BV]
+    dyv = dv_new_total
+    dyk = -(dv_new_total @ jnp.transpose(S_prev))  # [C, K]
+    dS_prev_local = dS_prev_local - jnp.transpose(yk) @ dv_new_total
 
-    dgt_from_alpha = alpha_tail * jnp.sum(S_prev * dS_in)
-    s_i = jnp.sum(kv_dS * v_new, axis=-1)  # (C,)
-    dgt_from_w = jnp.sum(w * s_i)
-    dgc_from_w = -w * s_i
-
-    # SAFE update at tail index (active-1) without Python if:
-    def _add_tail(_):
-        idx = active - jnp.int32(1)
-        base = dgc_from_w
-        cur = lax.dynamic_slice_in_dim(base, idx, 1, axis=0)[0]
-        upd = cur + (dgt_from_alpha + dgt_from_w)
-        return lax.dynamic_update_slice_in_dim(base, upd[None], idx, axis=0)
-
-    dgc_carry = lax.cond(active > 0, _add_tail, lambda _: dgc_from_w, operand=None)
-    dS_prev_carry = alpha_tail * dS_in
-
-    # backward triangular solved contributions (Ā) for yv/yk
-    def bwd_sub_yv():
-        d_rhs = jnp.zeros((C, BV), jnp.float32)
+    # -------------------------------------------------------------------------
+    # Backward‑substitution through the two triangular solves (bounded by 'active')
+    # Produces:
+    #   d_rhs_v ∈ ℝ^{C×BV}, dAbar_v ∈ ℝ^{C×C}
+    #   d_rhs_k ∈ ℝ^{C×K},  dAbar_k ∈ ℝ^{C×C}
+    # -------------------------------------------------------------------------
+    def bwd_sub(dy, width, is_vec_rhs):
+        # dy: [C, width]; returns (d_rhs: [C, width], dAbar: [C, C])
+        d_rhs = jnp.zeros((C, width), jnp.float32)
         dAbar = jnp.zeros((C, C), jnp.float32)
 
         def row_rev(i_rev, state):
             d_rhs_cur, dA = state
             i = active - 1 - i_rev
-            dyi = lax.dynamic_slice(dyv, (i, 0), (1, BV))[0]
+            dyi = lax.dynamic_slice(dy, (i, 0), (1, width))[0]
             d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, dyi[None, :], (i, 0))
 
-            def upd_j(j, carry):
-                dA_cur, d_rhs_inner = carry
-                aij0 = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+            def upd_j(j, inner):
+                dA_cur, d_rhs_inner = inner
+                aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
                 decay = jnp.exp(g_cum[i] - g_cum[j])
-                yj = lax.dynamic_slice(yv, (j, 0), (1, BV))[0]
+                yj = lax.dynamic_slice(d_rhs_cur, (j, 0), (1, width))[
+                    0
+                ]  # back‑sub structure uses already‑accumulated RHS
                 # dAbar[i,j] += <dyi, yj>
                 val = lax.dynamic_slice(dA_cur, (i, j), (1, 1))[0, 0] + jnp.sum(dyi * yj)
                 dA_cur = lax.dynamic_update_slice(dA_cur, jnp.asarray([[val]], jnp.float32), (i, j))
+                # d_rhs[j] += (aij * decay) * dyi
                 d_rhs_inner = lax.dynamic_update_slice(
                     d_rhs_inner,
-                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, BV))[0] + (aij0 * decay) * dyi)[None, :],
+                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, width))[0] + (aij * decay) * dyi)[None, :],
                     (j, 0),
                 )
                 return (dA_cur, d_rhs_inner)
@@ -1828,42 +1842,14 @@ def _gdn_chunk_bwd_kernel_fused(
 
         return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
 
-    d_rhs_v, dAbar_v = bwd_sub_yv()
+    d_rhs_v, dAbar_v = bwd_sub(dyv, BV, True)  # seeds from dv_new_total
+    d_rhs_k, dAbar_k = bwd_sub(dyk, K, False)
 
-    def bwd_sub_yk():
-        d_rhs = jnp.zeros((C, K), jnp.float32)
-        dAbar = jnp.zeros((C, C), jnp.float32)
+    dAbar = dAbar_v + dAbar_k  # [C, C]
 
-        def row_rev(i_rev, state):
-            d_rhs_cur, dA = state
-            i = active - 1 - i_rev
-            dyi = lax.dynamic_slice(dyk, (i, 0), (1, K))[0]
-            d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, dyi[None, :], (i, 0))
-
-            def upd_j(j, carry):
-                dA_cur, d_rhs_inner = carry
-                aij0 = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-                decay = jnp.exp(g_cum[i] - g_cum[j])
-                yj = lax.dynamic_slice(yk, (j, 0), (1, K))[0]
-                val = lax.dynamic_slice(dA_cur, (i, j), (1, 1))[0, 0] + jnp.sum(dyi * yj)
-                dA_cur = lax.dynamic_update_slice(dA_cur, jnp.asarray([[val]], jnp.float32), (i, j))
-                d_rhs_inner = lax.dynamic_update_slice(
-                    d_rhs_inner,
-                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, K))[0] + (aij0 * decay) * dyi)[None, :],
-                    (j, 0),
-                )
-                return (dA_cur, d_rhs_inner)
-
-            dA, d_rhs_cur = lax.fori_loop(0, i, upd_j, (dA, d_rhs_cur))
-            return (d_rhs_cur, dA)
-
-        return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
-
-    d_rhs_k, dAbar_k = bwd_sub_yk()
-
-    dAbar = dAbar_v + dAbar_k
-
-    # map dAbar → dA0 and d g_cum
+    # -------------------------------------------------------------------------
+    # Map dAbar → (dA0, d g_cum)   with  A = (A0 ⊙ decay), strictly lower
+    # -------------------------------------------------------------------------
     dA0 = jnp.zeros_like(A0)
     dgc_from_A = jnp.zeros((C,), jnp.float32)
 
@@ -1878,23 +1864,27 @@ def _gdn_chunk_bwd_kernel_fused(
             # dA0 += dAbar * decay
             val = lax.dynamic_slice(dA0_i, (i, j), (1, 1))[0, 0] + dAij * decay
             dA0_i = lax.dynamic_update_slice(dA0_i, jnp.asarray([[val]], jnp.float32), (i, j))
-            # g_cum: + on i, - on j
+            # d g_cum: + on i, − on j
             dgc_i = dgc_i.at[i].add(dAij * aij0 * decay)
             dgc_i = dgc_i.at[j].add(-dAij * aij0 * decay)
             return (dA0_i, dgc_i)
 
-        return lax.fori_loop(0, i, col, (dA0_cur, dgc_cur))
+        return lax.fori_loop(1, i + 1, col, (dA0_cur, dgc_cur))  # j ∈ [0, i-1]
 
     dA0, dgc_from_A = lax.fori_loop(1, active, tri_map, (dA0, dgc_from_A))
 
+    # -------------------------------------------------------------------------
     # RHS contributions
-    dV_tile = b_c[:, None] * d_rhs_v
-    dB_from_v = jnp.sum(v_c * d_rhs_v, axis=-1)
-    dK_rhs = (eg[:, None] * b_c[:, None]) * d_rhs_k
-    dB_from_k = jnp.sum((eg[:, None] * k_c) * d_rhs_k, axis=-1)
-    dgc_from_rhs_k = eg * jnp.sum((b_c[:, None] * k_c) * d_rhs_k, axis=-1)
+    # -------------------------------------------------------------------------
+    dV_tile = (b_c[:, None] * d_rhs_v) * m[:, None]  # [C, BV]
+    dB_from_v = jnp.sum(v_c * d_rhs_v, axis=-1)  # [C]
+    dK_rhs = (eg[:, None] * b_c[:, None]) * d_rhs_k  # [C, K]
+    dB_from_k = jnp.sum((eg[:, None] * k_c) * d_rhs_k, axis=-1)  # [C]
+    dgc_from_k = eg * jnp.sum((b_c[:, None] * k_c) * d_rhs_k, axis=-1)  # [C]
 
-    # dA0 → dK and dβ, via A0[i,j] = -β_i <k_i, k_j>
+    # -------------------------------------------------------------------------
+    # From A0:  A0[i,j] = -β_i <k_i, k_j>    (i > j)
+    # -------------------------------------------------------------------------
     dK_from_A0 = jnp.zeros_like(k_c)
     dB_from_A0 = jnp.zeros((C,), jnp.float32)
 
@@ -1905,25 +1895,55 @@ def _gdn_chunk_bwd_kernel_fused(
         def body(j, carry):
             dK_a, dB_a = carry
             kj = lax.dynamic_slice(k_c, (j, 0), (1, K))[0]
-            coeff = -(dA0[i, j] * b_c[i])
-            dK_a = dK_a.at[i, :].add(coeff * kj)
-            dK_a = dK_a.at[j, :].add(coeff * ki)
-            dB_a = dB_a + (-dA0[i, j]) * jnp.sum(ki * kj)
+            dAij = lax.dynamic_slice(dA0, (i, j), (1, 1))[0, 0]
+            coeff = -(dAij * b_c[i])  # - dA0[i,j] * β_i
+            dK_a = dK_a.at[i, :].add(coeff * kj)  # ∂/∂k_i
+            dK_a = dK_a.at[j, :].add(coeff * ki)  # ∂/∂k_j
+            dB_a = dB_a + (-dAij) * jnp.sum(ki * kj)
             return (dK_a, dB_a)
 
         return lax.fori_loop(0, i, body, (dK_acc, dB_acc))
 
     dK_from_A0, dB_from_A0 = lax.fori_loop(1, active, gram_bwd, (dK_from_A0, dB_from_A0))
 
-    # collect per-chunk grads
-    dQ_tile = dQ_inter + dQ_attn
-    dK_tile = dK_attn + dK_add + dK_rhs + dK_from_A0
-    dB_tile = (dB_from_v + dB_from_k + dB_from_A0) * m
-    dgc_total = (dgc_inter + dgc_attn + dgc_from_A + dgc_from_rhs_k + dgc_carry) * m
+    # -------------------------------------------------------------------------
+    # Carry‑direct gradient wrt k:  dK_add (no triangular involvement)
+    #   S_out += Σ_i w_i k_i v_new_i^T  ⇒  dK_add[i,:] = w_i * (dS_in @ v_new_i)  (rowwise)
+    # -------------------------------------------------------------------------
+    dK_add = ((dS_in @ jnp.transpose(v_new)).T) * w[:, None]  # [C, K]
 
-    # reverse-cumsum d g_cum → d g, avoiding dynamic jnp.pad
+    # -------------------------------------------------------------------------
+    # Collect per‑chunk grads
+    # -------------------------------------------------------------------------
+    dQ_attn = dQ_attn * m[:, None]
+    dQ_inter = dQ_inter * m[:, None]
+
+    dK_tile = (dK_attn + dK_rhs + dK_from_A0 + dK_add) * m[:, None]
+    dB_tile = (dB_from_v + dB_from_k + dB_from_A0) * m
+
+    # d g: combine all sources on g_cum then reverse‑cumsum to get d g
+    dgc_total = (dgc_attn + dgc_from_A + dgc_from_k) * m
+
+    # carry contributions on g and S_prev:
+    #   S_out = α_tail S_prev + Σ_i w_i k_i v_new_i^T
+    #   g_tail receives (d/dg_tail) from both α_tail and w
+    s_i = jnp.sum(kv_dS * v_new, axis=-1)  # [C]
+    dgt_from_w = jnp.sum(w * s_i)  # scalar
+    dgc_from_w = -w * s_i  # [C]
+    dgt_from_alpha = alpha_tail * jnp.sum(S_prev * dS_in)  # scalar
+
+    def _add_tail(_):
+        idx = active - jnp.int32(1)
+        base = dgc_from_w
+        cur = lax.dynamic_slice_in_dim(base, idx, 1, axis=0)[0]
+        upd = cur + (dgt_from_alpha + dgt_from_w)
+        return lax.dynamic_update_slice_in_dim(base, upd[None], idx, axis=0)
+
+    dgc_carry = lax.cond(active > 0, _add_tail, lambda _: dgc_from_w, operand=None)
+    dgc_total = dgc_total + dgc_carry
+
+    # reverse‑cumsum: d g_cum → d g
     def rev_cumsum_full(x):
-        # returns length-C vector; only positions < active are written
         def body(i_rev, carry):
             acc, out_vec = carry
             i = active - jnp.int32(1) - i_rev
@@ -1936,17 +1956,28 @@ def _gdn_chunk_bwd_kernel_fused(
         _, out_vec = lax.fori_loop(0, active, body, init)
         return out_vec
 
-    dG_tile = rev_cumsum_full(dgc_total)
+    dG_tile = rev_cumsum_full(dgc_total)  # [C]
 
-    dS_out = dS_prev_local + dS_prev_carry
+    # S_prev: local (inter + v_new path) + carry α_tail
+    dS_out = (dS_prev_local + alpha_tail * dS_in).astype(jnp.float32)
 
-    # writes
-    dQ_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dQ_tile[None, None, :, :]
+    # dV tile already masked above; ensure dtype matches out ref
+    dV_tile = dV_tile * m[:, None]
+
+    # -------------------------------------------------------------------------
+    # Writes
+    # -------------------------------------------------------------------------
+    dQ_attn_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dQ_attn[None, None, :, :]
+    dQ_inter_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dQ_inter[None, None, :, :]
     dK_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_tile[None, None, :, :]
     dV_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, BV)] = dV_tile[None, None, :, :]
     dG_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dG_tile[None, None, :]
     dB_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dB_tile[None, None, :]
     dS_out_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)] = dS_out[None, :, :]
+
+
+# ---------- fused backward (chunk) launcher ----------
+# NOTE: does the L2-norm backward *separately* for (dQ_attn, dQ_inter), then sums.
 
 
 def _chunk_gated_delta_rule_flash_bwd_fused(
@@ -1963,78 +1994,92 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
     initial_state_was_none: bool,
     use_qk_l2norm_in_kernel: bool,
 ):
-    A0_buf = aux["A0_buf"]
-    S_prev_buf = aux["S_prev_buf"]
-    T_pad = int(aux["T_pad"])  # padded time length used in fwd
+    """Backward wrapper for the flash chunk kernel.
+
+    Instrumented: emits per-chunk diffs for dQ_attn/inter (already good),
+    and for dK per-term (attn, RHS(yk), A0/Gram, and add/carry), using
+    both OUT-only seeds and TOTAL seeds, masked for ragged rows.
+    """
+
+    _DBG = bool(int(os.environ.get("GDN_DEBUG_CHUNK_BWD", "0")))
+
+    # ---- unpack aux / static sizes from forward ----
+    A0_buf = aux["A0_buf"]  # [NH, Nc, C, C]
+    S_prev_buf = aux["S_prev_buf"]  # [NH, Nc, K, V_pad]
+    T_pad = int(aux["T_pad"])
     K = int(aux["K"])
-    V_pad = int(aux["V_pad"])  # padded value dim used in fwd
+    V_pad = int(aux["V_pad"])
     C = int(aux["C"])
     NH = int(aux["NH"])
     Nc = int(aux["Nc"])
 
-    # ---------- helpers: pad along time and value ----------
+    # ---------- helpers ----------
     def _pad_time(x, t_pad):
-        """Pad axis=1 (time) of an NH-major array to t_pad."""
         t = x.shape[1]
-        if t == t_pad:
-            return x
-        return jnp.pad(x, ((0, 0), (0, t_pad - t)) + ((0, 0),) * (x.ndim - 2))
+        return x if t == t_pad else jnp.pad(x, ((0, 0), (0, t_pad - t)) + ((0, 0),) * (x.ndim - 2))
 
     def _pad_time_and_feat(x, t_pad, v_pad):
-        """Pad axis=1 (time) to t_pad and last axis (value) to v_pad."""
-        t, v = x.shape[1], x.shape[-1]
-        if t != t_pad:
-            x = jnp.pad(x, ((0, 0), (0, t_pad - t)) + ((0, 0),) * (x.ndim - 2))
-        if v != v_pad:
-            x = jnp.pad(x, ((0, 0), (0, 0)) + ((0, v_pad - v),))
+        if x.shape[1] != t_pad:
+            x = jnp.pad(x, ((0, 0), (0, t_pad - x.shape[1])) + ((0, 0),) * (x.ndim - 2))
+        if x.shape[-1] != v_pad:
+            x = jnp.pad(x, ((0, 0), (0, 0), (0, v_pad - x.shape[-1])))
         return x
 
-    # ---------- layout-normalize inputs to NH-major and pad to T_pad/V_pad ----------
+    def _l2norm_bwd_rows(dY_norm, X_raw, scale):
+        eps = jnp.asarray(1e-6, jnp.float32)
+        inv = lax.rsqrt(jnp.sum(X_raw * X_raw, axis=-1, keepdims=True) + eps)
+        dot = jnp.sum(dY_norm * X_raw, axis=-1, keepdims=True)
+        return scale * (inv * dY_norm - (inv**3) * X_raw * dot)
+
+    # ---------- normalize layout to NH-major (RAW views) ----------
     if head_first:
-        # q,k: [B,H,L,K]  → [NH, L, K]
         B, H, L, _K = q_arr.shape
-        _ = _K  # silence lints
-        q_LK = jnp.transpose(q_arr, (0, 2, 1, 3)).reshape(NH, L, K)
-        k_LK = jnp.transpose(k_arr, (0, 2, 1, 3)).reshape(NH, L, K)
-        # v: [B,H,L,V]   → [NH, L, V]
         V = v_arr.shape[-1]
-        v_LV = jnp.transpose(v_arr, (0, 2, 1, 3)).reshape(NH, L, V)
-        # g,b: [B,H,L]   → [NH, L]
-        g_L = jnp.transpose(g_arr, (0, 2, 1)).reshape(NH, L)
-        b_L = jnp.transpose(beta_arr, (0, 2, 1)).reshape(NH, L)
-        # dY: [B,H,L,V]  → [NH, L, V]
-        dY_LV = jnp.transpose(d_out_arr, (0, 2, 1, 3)).reshape(NH, L, V)
+        q_LK_raw = q_arr.reshape(B * H, L, K)
+        k_LK_raw = k_arr.reshape(B * H, L, K)
+        v_LV = v_arr.reshape(B * H, L, V)
+        g_L = g_arr.reshape(B * H, L)
+        b_L = beta_arr.reshape(B * H, L)
+        dY_LV = d_out_arr.reshape(B * H, L, V)
     else:
-        # q,k: [B,L,H,K] → [NH, L, K]
         B, L, H, _K = q_arr.shape
-        _ = _K
-        q_LK = q_arr.reshape(NH, L, K)
-        k_LK = k_arr.reshape(NH, L, K)
-        # v: [B,L,H,V]   → [NH, L, V]
         V = v_arr.shape[-1]
-        v_LV = v_arr.reshape(NH, L, V)
-        # g,b: [B,L,H]   → [NH, L]
-        g_L = g_arr.reshape(NH, L)
-        b_L = beta_arr.reshape(NH, L)
-        # dY: [B,L,H,V]  → [NH, L, V]
-        dY_LV = d_out_arr.reshape(NH, L, V)
+        q_LK_raw = jnp.transpose(q_arr, (0, 2, 1, 3)).reshape(B * H, L, K)
+        k_LK_raw = jnp.transpose(k_arr, (0, 2, 1, 3)).reshape(B * H, L, K)
+        v_LV = jnp.transpose(v_arr, (0, 2, 1, 3)).reshape(B * H, L, V)
+        g_L = jnp.transpose(g_arr, (0, 2, 1)).reshape(B * H, L)
+        b_L = jnp.transpose(beta_arr, (0, 2, 1)).reshape(B * H, L)
+        dY_LV = jnp.transpose(d_out_arr, (0, 2, 1, 3)).reshape(B * H, L, V)
 
-    # === PAD to T_pad / V_pad so chunk slicing works for the last chunk ===
-    q_flat = _pad_time(q_LK, T_pad).astype(jnp.float32)  # [NH, T_pad, K]
-    k_flat = _pad_time(k_LK, T_pad).astype(jnp.float32)  # [NH, T_pad, K]
-    g_flat = _pad_time(g_L, T_pad).astype(jnp.float32)  # [NH, T_pad]
-    b_flat = _pad_time(b_L, T_pad).astype(jnp.float32)  # [NH, T_pad]
-    v_flat = _pad_time_and_feat(v_LV, T_pad, V_pad).astype(jnp.float32)  # [NH, T_pad, V_pad]
-    dY_full = _pad_time_and_feat(dY_LV, T_pad, V_pad).astype(jnp.float32)  # [NH, T_pad, V_pad]
+    # === PAD raw q/k (for final L2 backward) ===
+    q_flat_raw = _pad_time(q_LK_raw.astype(jnp.float32), T_pad)  # [NH, T_pad, K]
+    k_flat_raw = _pad_time(k_LK_raw.astype(jnp.float32), T_pad)  # [NH, T_pad, K]
 
-    # ---------- init grads ----------
-    dQ_flat = jnp.zeros_like(q_flat, dtype=jnp.float32)
-    dK_flat = jnp.zeros_like(k_flat, dtype=jnp.float32)
+    # === Reconstruct the *forward* normalized q,k to feed the backward kernel ===
+    if use_qk_l2norm_in_kernel:
+        eps = 1e-6
+        qn = jnp.sqrt(jnp.sum(q_flat_raw * q_flat_raw, axis=-1, keepdims=True) + eps)
+        kn = jnp.sqrt(jnp.sum(k_flat_raw * k_flat_raw, axis=-1, keepdims=True) + eps)
+        q_flat_fwd = (q_flat_raw / jnp.where(qn > 0.0, qn, 1.0)) * (K**-0.5)
+        k_flat_fwd = k_flat_raw / jnp.where(kn > 0.0, kn, 1.0)
+    else:
+        q_flat_fwd = q_flat_raw * (K**-0.5)
+        k_flat_fwd = k_flat_raw
+
+    # === PAD other tensors used during the backward sweep ===
+    v_flat = _pad_time_and_feat(v_LV.astype(jnp.float32), T_pad, V_pad)
+    g_flat = _pad_time(g_L.astype(jnp.float32), T_pad)
+    b_flat = _pad_time(b_L.astype(jnp.float32), T_pad)
+    dY_full = _pad_time_and_feat(dY_LV.astype(jnp.float32), T_pad, V_pad)
+
+    # Initialize grads wrt *normalized* q,k (the kernel space)
+    dQ_flat_norm = jnp.zeros_like(q_flat_fwd, dtype=jnp.float32)
+    dK_flat_norm = jnp.zeros_like(k_flat_fwd, dtype=jnp.float32)
     dV_flat = jnp.zeros_like(v_flat, dtype=jnp.float32)
     dG_flat = jnp.zeros_like(g_flat, dtype=jnp.float32)
     dB_flat = jnp.zeros_like(b_flat, dtype=jnp.float32)
 
-    # lengths per NH
+    # lengths per NH (varlen)
     if lengths is None:
         lengths_flat = jnp.full((NH,), T_pad, dtype=jnp.int32)
     else:
@@ -2042,62 +2087,168 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
         lf = lf.reshape(-1) if lf.ndim == 2 else lf
         lengths_flat = jnp.clip(lf, 0, jnp.int32(T_pad))
 
+    # Tile along V
     BV = min(64 if V_pad >= 128 else 32, V_pad)
     n_vtiles = V_pad // BV
 
-    # reverse carry dS (NH, K, V_pad)
+    # Reverse carry dS (NH, K, V_pad)
     dS_carry = jnp.zeros((NH, K, V_pad), dtype=jnp.float32)
 
-    kernel = functools.partial(
-        _gdn_chunk_bwd_kernel_fused,
-        C=int(C),
-        K=int(K),
-        BV=int(BV),
-    )
+    # --- small helpers for the per-chunk reference math (debug only) ---
+    def _fs_yv_ref(A0, g_cum, beta, v_chunk, active):
+        """Forward-sub solve Y = T (β v). Shapes NH×C×(BV or V_pad)."""
+        NH_, C_, V_ = v_chunk.shape
+        Y = jnp.zeros((NH_, C_, V_), jnp.float32)
+
+        def row_i(i, Ycur):
+            rhs_i = (beta[:, i][:, None] * v_chunk[:, i, :]).astype(jnp.float32)
+
+            def add_j(j, acc):
+                aij = A0[:, i, j]
+                decay = jnp.exp(g_cum[:, i] - g_cum[:, j])
+                yj = lax.dynamic_slice(Ycur, (0, j, 0), (NH_, 1, V_))[:, 0, :]
+                return acc + (aij * decay)[:, None] * yj
+
+            contrib = lax.fori_loop(0, i, add_j, jnp.zeros((NH_, V_), jnp.float32))
+            yi = rhs_i + contrib
+            return lax.dynamic_update_slice(Ycur, yi[:, None, :], (0, i, 0))
+
+        return lax.fori_loop(0, active, row_i, Y)
+
+    def _fs_yk_ref(A0, g_cum, beta, k_chunk, active):
+        """Forward-sub solve Y = T (exp(g_cum) ⊙ β ⊙ k). Shapes NH×C×K."""
+        NH_, C_, K_ = k_chunk.shape
+        Y = jnp.zeros((NH_, C_, K_), jnp.float32)
+        eg = jnp.exp(g_cum)
+
+        def row_i(i, Ycur):
+            rhs_i = (eg[:, i][:, None] * beta[:, i][:, None] * k_chunk[:, i, :]).astype(jnp.float32)
+
+            def add_j(j, acc):
+                aij = A0[:, i, j]
+                decay = jnp.exp(g_cum[:, i] - g_cum[:, j])
+                yj = lax.dynamic_slice(Ycur, (0, j, 0), (NH_, 1, K_))[:, 0, :]
+                return acc + (aij * decay)[:, None] * yj
+
+            contrib = lax.fori_loop(0, i, add_j, jnp.zeros((NH_, K_), jnp.float32))
+            yi = rhs_i + contrib
+            return lax.dynamic_update_slice(Ycur, yi[:, None, :], (0, i, 0))
+
+        return lax.fori_loop(0, active, row_i, Y)
+
+    def _bwd_sub_ref(dY, A0, g_cum, Y, active):
+        """Backward-sub of lower-triangular forward-substitution.
+        Returns (d_rhs, dAbar). Shapes match Y."""
+        NH_, C_, D_ = Y.shape
+        d_rhs = jnp.zeros((NH_, C_, D_), jnp.float32)
+        dAbar = jnp.zeros((NH_, C_, C_), jnp.float32)  # lower-tri slots will be used
+
+        def row_rev(i_rev, state):
+            d_rhs_cur, dA = state
+            i = active - 1 - i_rev
+            dyi = lax.dynamic_slice(dY, (0, i, 0), (NH_, 1, D_))[:, 0, :]
+            # accumulate into rhs
+            d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, dyi[:, None, :], (0, i, 0))
+
+            # accumulate into earlier rows and dA
+            def upd_j(j, inner):
+                dA_cur, d_rhs_inner = inner
+                aij0 = A0[:, i, j]  # [NH]
+                decay = jnp.exp(g_cum[:, i] - g_cum[:, j])  # [NH]
+                yj = lax.dynamic_slice(Y, (0, j, 0), (NH_, 1, D_))[:, 0, :]  # [NH, D]
+                # dAbar[i,j] += <dyi, yj>
+                val = lax.dynamic_slice(dA_cur, (0, i, j), (NH_, 1, 1))[:, 0, 0] + jnp.sum(dyi * yj, axis=-1)
+                dA_cur = lax.dynamic_update_slice(dA_cur, val[:, None, None], (0, i, j))
+                # back-prop to yj
+                d_rhs_inner = lax.dynamic_update_slice(
+                    d_rhs_inner,
+                    (lax.dynamic_slice(d_rhs_inner, (0, j, 0), (NH_, 1, D_))[:, 0, :] + (aij0 * decay)[:, None] * dyi)[
+                        :, None, :
+                    ],
+                    (0, j, 0),
+                )
+                return (dA_cur, d_rhs_inner)
+
+            return lax.fori_loop(0, i, upd_j, (dA, d_rhs_cur))
+
+        return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
+
+    def _gram_bwd_k(dA0, beta_c, k_chunk, active):
+        """Map dA0 (lower-tri) back to k via A0[i,j] = -β_i <k_i, k_j>"""
+        NH_, C_, K_ = k_chunk.shape
+        dK = jnp.zeros((NH_, C_, K_), jnp.float32)
+        dB = jnp.zeros((NH_, C_), jnp.float32)  # not printed here
+
+        def row_i(i, state):
+            dK_acc, dB_acc = state
+            ki = k_chunk[:, i, :]  # [NH, K]
+
+            def col_j(j, inner):
+                dK_a, dB_a = inner
+                kj = k_chunk[:, j, :]
+                coeff = -(lax.dynamic_slice(dA0, (0, i, j), (NH_, 1, 1))[:, 0, 0] * beta_c[:, i])  # [NH]
+                dK_a = dK_a.at[:, i, :].add(coeff[:, None] * kj)
+                dK_a = dK_a.at[:, j, :].add(coeff[:, None] * ki)
+                dB_a = dB_a.at[:, i].add(
+                    -(lax.dynamic_slice(dA0, (0, i, j), (NH_, 1, 1))[:, 0, 0]) * jnp.sum(ki * kj, axis=-1)
+                )
+                return (dK_a, dB_a)
+
+            return lax.fori_loop(0, i, col_j, (dK_acc, dB_acc))
+
+        return lax.fori_loop(1, active, row_i, (dK, dB))[0]  # return dK only
+
+    kernel = functools.partial(_gdn_chunk_bwd_kernel_fused, C=int(C), K=int(K), BV=int(BV))
 
     # ---------- reverse over chunks ----------
-    def one_chunk(ci, dS_in):
+    def one_chunk(carry, i):
+        dQ_acc, dK_acc, dV_acc, dG_acc, dB_acc, dS_in = carry
+        ci = jnp.int32(Nc - 1 - i)
         c0 = ci * C
         lengths_chunk = jnp.clip(lengths_flat - jnp.int32(c0), 0, jnp.int32(C))  # [NH]
+        active = jnp.min(lengths_chunk)  # all batches in test are full; we still mask below
 
-        # slice per-chunk tensors OUTSIDE the kernel (static sizes inside)
-        q_chunk = jax.lax.dynamic_slice(q_flat, (0, c0, 0), (NH, C, K))
-        k_chunk = jax.lax.dynamic_slice(k_flat, (0, c0, 0), (NH, C, K))
-        g_chunk = jax.lax.dynamic_slice(g_flat, (0, c0), (NH, C))
-        b_chunk = jax.lax.dynamic_slice(b_flat, (0, c0), (NH, C))
-        A0_chunk = jax.lax.dynamic_slice(A0_buf, (0, ci, 0, 0), (NH, 1, C, C)).squeeze(1)
-        dY_chunk = jax.lax.dynamic_slice(dY_full, (0, c0, 0), (NH, C, V_pad))
-        S_prev_chunk = jax.lax.dynamic_slice(S_prev_buf, (0, ci, 0, 0), (NH, 1, K, V_pad)).squeeze(1)
+        # slice per-chunk tensors (outside the kernel; static sizes inside)
+        q_chunk_fwd = lax.dynamic_slice(q_flat_fwd, (0, c0, 0), (NH, C, K))
+        k_chunk_fwd = lax.dynamic_slice(k_flat_fwd, (0, c0, 0), (NH, C, K))
+        v_chunk = lax.dynamic_slice(v_flat, (0, c0, 0), (NH, C, V_pad))
+        g_chunk = lax.dynamic_slice(g_flat, (0, c0), (NH, C))
+        b_chunk = lax.dynamic_slice(b_flat, (0, c0), (NH, C))
+        dY_chunk = lax.dynamic_slice(dY_full, (0, c0, 0), (NH, C, V_pad))
+        A0_chunk = lax.dynamic_slice(A0_buf, (0, ci, 0, 0), (NH, 1, C, C)).squeeze(1)
+        S_prev_chunk = lax.dynamic_slice(S_prev_buf, (0, ci, 0, 0), (NH, 1, K, V_pad)).squeeze(1)
 
-        # per-chunk accumulators
-        dQ_c = jnp.zeros((NH, C, K), jnp.float32)
-        dK_c = jnp.zeros((NH, C, K), jnp.float32)
+        # per-chunk accumulators in kernel space (normalized)
+        dQ_c_norm = jnp.zeros((NH, C, K), jnp.float32)
+        dK_c_norm = jnp.zeros((NH, C, K), jnp.float32)
         dV_c = jnp.zeros((NH, C, V_pad), jnp.float32)
         dG_c = jnp.zeros((NH, C), jnp.float32)
         dB_c = jnp.zeros((NH, C), jnp.float32)
 
+        # ---- per-VT loop (kernel call) ----
         def one_vt(vt, acc):
-            dQ_acc, dK_acc, dV_acc, dG_acc, dB_acc, dS_in_prev = acc
+            dQ_acc_t, dK_acc_t, dV_acc_t, dG_acc_t, dB_acc_t, dS_in_prev = acc
 
-            v_tile = jax.lax.dynamic_slice(v_flat, (0, c0, vt * BV), (NH, C, BV))
-            dY_tile = jax.lax.dynamic_slice(dY_chunk, (0, 0, vt * BV), (NH, C, BV))
-            S_prev_t = jax.lax.dynamic_slice(S_prev_chunk, (0, 0, vt * BV), (NH, K, BV))
-            dS_in_t = jax.lax.dynamic_slice(dS_in, (0, 0, vt * BV), (NH, K, BV))
+            v_tile = lax.dynamic_slice(v_chunk, (0, 0, vt * BV), (NH, C, BV))
+            dY_tile = lax.dynamic_slice(dY_chunk, (0, 0, vt * BV), (NH, C, BV))
+            S_prev_t = lax.dynamic_slice(S_prev_chunk, (0, 0, vt * BV), (NH, K, BV))
+            dS_in_t = lax.dynamic_slice(dS_in, (0, 0, vt * BV), (NH, K, BV))
 
-            dQ_t, dK_t, dV_t, dG_t, dB_t, dS_out_t = pl.pallas_call(
+            dQ_attn_t, dQ_inter_t, dK_t, dV_t, dG_t, dB_t, dS_out_t = pl.pallas_call(
                 kernel,
                 out_shape=(
-                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),
-                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),
-                    jax.ShapeDtypeStruct((NH, 1, C, BV), jnp.float32),
-                    jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),
-                    jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),
-                    jax.ShapeDtypeStruct((NH, K, BV), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dQ_attn (normalized space)
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dQ_inter (normalized space)
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dK (all K terms)
+                    jax.ShapeDtypeStruct((NH, 1, C, BV), jnp.float32),  # dV
+                    jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),  # dG
+                    jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),  # dB
+                    jax.ShapeDtypeStruct((NH, K, BV), jnp.float32),  # dS_out
                 ),
                 grid=(NH,),
                 in_specs=(
-                    pl.BlockSpec((1, C, K), lambda nh: (nh, 0, 0)),  # q_chunk
-                    pl.BlockSpec((1, C, K), lambda nh: (nh, 0, 0)),  # k_chunk
+                    pl.BlockSpec((1, C, K), lambda nh: (nh, 0, 0)),  # q_chunk_fwd
+                    pl.BlockSpec((1, C, K), lambda nh: (nh, 0, 0)),  # k_chunk_fwd
                     pl.BlockSpec((1, C, BV), lambda nh: (nh, 0, 0)),  # v_tile
                     pl.BlockSpec((1, C), lambda nh: (nh, 0)),  # g_chunk
                     pl.BlockSpec((1, C), lambda nh: (nh, 0)),  # b_chunk
@@ -2110,145 +2261,260 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
                 out_specs=(
                     pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
                     pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
                     pl.BlockSpec((1, 1, C, BV), lambda nh: (nh, 0, 0, 0)),
                     pl.BlockSpec((1, 1, C), lambda nh: (nh, 0, 0)),
                     pl.BlockSpec((1, 1, C), lambda nh: (nh, 0, 0)),
                     pl.BlockSpec((1, K, BV), lambda nh: (nh, 0, 0)),
                 ),
                 interpret=_should_interpret_pallas(),
-            )(q_chunk, k_chunk, v_tile, g_chunk, b_chunk, A0_chunk, S_prev_t, dY_tile, dS_in_t, lengths_chunk)
+            )(
+                q_chunk_fwd,
+                k_chunk_fwd,
+                v_tile,
+                g_chunk,
+                b_chunk,
+                A0_chunk,
+                S_prev_t,
+                dY_tile,
+                dS_in_t,
+                lengths_chunk,
+            )
 
-            dQ_acc = dQ_acc + dQ_t[:, 0, :, :]
-            dK_acc = dK_acc + dK_t[:, 0, :, :]
-
+            # accumulate ONLY attention part for Q; add inter once per chunk below
+            dQ_acc_t = dQ_acc_t + dQ_attn_t[:, 0, :, :]
+            # K/V/G/B accumulate as usual
+            dK_acc_t = dK_acc_t + dK_t[:, 0, :, :]
+            # tile-scatter for V
             start = vt * jnp.int32(BV)
-
-            dv_old = lax.dynamic_slice(dV_acc, (0, 0, start), (NH, C, BV))
+            dv_old = lax.dynamic_slice(dV_acc_t, (0, 0, start), (NH, C, BV))
             dv_new = dv_old + dV_t[:, 0, :, :]
-            dV_acc = lax.dynamic_update_slice(dV_acc, dv_new, (0, 0, start))
-
-            dG_acc = dG_acc + dG_t[:, 0, :]
-            dB_acc = dB_acc + dB_t[:, 0, :]
+            dV_acc_t = lax.dynamic_update_slice(dV_acc_t, dv_new, (0, 0, start))
+            # G/B (row-wise)
+            dG_acc_t = dG_acc_t + dG_t[:, 0, :]
+            dB_acc_t = dB_acc_t + dB_t[:, 0, :]
+            # pass dS_out along V-tiles
             dS_in_prev = lax.dynamic_update_slice(dS_in_prev, dS_out_t, (0, 0, start))
-            return (dQ_acc, dK_acc, dV_acc, dG_acc, dB_acc, dS_in_prev)
+            return (dQ_acc_t, dK_acc_t, dV_acc_t, dG_acc_t, dB_acc_t, dS_in_prev)
 
-        dQ_c, dK_c, dV_c, dG_c, dB_c, dS_out = lax.fori_loop(
-            0, n_vtiles, one_vt, (dQ_c, dK_c, dV_c, dG_c, dB_c, jnp.zeros_like(dS_in))
+        dQ_c_norm, dK_c_norm, dV_c, dG_c, dB_c, dS_out = lax.fori_loop(
+            0, n_vtiles, one_vt, (dQ_c_norm, dK_c_norm, dV_c, dG_c, dB_c, jnp.zeros_like(dS_in))
         )
 
-        # scatter per-chunk grads
-        old = lax.dynamic_slice(dQ_flat, (0, c0, 0), (NH, C, K))
-        dQ_sc = lax.dynamic_update_slice(dQ_flat, old + dQ_c, (0, c0, 0))
+        # === add dQ_inter once (full-V) ===
+        eg_full = jnp.exp(jnp.cumsum(g_chunk, axis=1))  # [NH,C]
+        dQ_inter_chunk = (dY_chunk @ jnp.transpose(S_prev_chunk, (0, 2, 1))) * eg_full[:, :, None]
+        dQ_attn_only = dQ_c_norm
+        dQ_c_norm = dQ_c_norm + dQ_inter_chunk
 
-        old = lax.dynamic_slice(dK_flat, (0, c0, 0), (NH, C, K))
-        dK_sc = lax.dynamic_update_slice(dK_flat, old + dK_c, (0, c0, 0))
+        # ---------- DEBUG: dQ paths (should be ~0 diffs already) ----------
+        if _DBG:
+            # inter
+            diff_inter = dQ_inter_chunk - ((dY_chunk @ jnp.transpose(S_prev_chunk, (0, 2, 1))) * eg_full[:, :, None])
+            max_abs = jnp.max(jnp.abs(diff_inter))
+            nh0_max = jnp.max(jnp.abs(diff_inter[0]))
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} NH={NH} C={C} K={K}  dQ_inter  max|Δ|={ma:.3e}  NH0 max|Δ|={m0:.3e}",
+                ci=ci,
+                NH=jnp.array(NH),
+                C=jnp.array(C),
+                K=jnp.array(K),
+                ma=max_abs,
+                m0=nh0_max,
+            )
+            # attn (recompute ref)
+            g_cum = jnp.cumsum(g_chunk, axis=1)
+            eg = jnp.exp(g_cum)
+            yv_ref = _fs_yv_ref(A0_chunk, g_cum, b_chunk, v_chunk, active)
+            yk_ref = _fs_yk_ref(A0_chunk, g_cum, b_chunk, k_chunk_fwd, active)
+            v_new_ref = yv_ref - jnp.einsum("nck,nkv->ncv", yk_ref, S_prev_chunk)
+            # qk_raw = jnp.einsum("nck,ndk->ncd", q_chunk_fwd, k_chunk_fwd)
+            decay = jnp.exp(g_cum[:, :, None] - g_cum[:, None, :])
+            tril = jnp.tril(jnp.ones((C, C), jnp.float32))[None, :, :]
+            M_full = decay * tril
+            dAttn_ref = jnp.einsum("ncv,nwv->ncw", dY_chunk, v_new_ref)
+            dQ_attn_ref = jnp.einsum("ncw,nwk->nck", M_full * dAttn_ref, k_chunk_fwd)
+            diff_attn = (jnp.where(jnp.arange(C)[None, :] < lengths_chunk[:, None], 1.0, 0.0)[:, :, None]) * (
+                dQ_attn_only - dQ_attn_ref
+            )
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} NH={NH} C={C} K={K}  dQ_attn  max|Δ|={m:.3e}",
+                ci=ci,
+                NH=jnp.array(NH),
+                C=jnp.array(C),
+                K=jnp.array(K),
+                m=jnp.max(jnp.abs(diff_attn)),
+            )
 
-        old = lax.dynamic_slice(dV_flat, (0, c0, 0), (NH, C, V_pad))
-        dV_sc = lax.dynamic_update_slice(dV_flat, old + dV_c, (0, c0, 0))
+        # ---------- DEBUG: K per-term reference and diffs ----------
+        if _DBG:
+            # Shapes
+            # q_chunk_fwd:  [NH, C, K]
+            # k_chunk_fwd:  [NH, C, K]
+            # v_chunk:      [NH, C, V_pad]
+            # g_chunk:      [NH, C]
+            # b_chunk:      [NH, C]
+            # A0_chunk:     [NH, C, C]
+            # S_prev_chunk: [NH, K, V_pad]
+            # dY_chunk:     [NH, C, V_pad]
+            # dS_in:        [NH, K, V_pad]  (incoming carry to this chunk)
+            g_cum = jnp.cumsum(g_chunk, axis=1)  # [NH, C]
+            eg = jnp.exp(g_cum)  # [NH, C]
+            tril = jnp.tril(jnp.ones((C, C), jnp.float32))[None, :, :]  # [1, C, C]
+            decay = jnp.exp(g_cum[:, :, None] - g_cum[:, None, :])  # [NH, C, C]
+            M_full = decay * tril  # [NH, C, C]
 
-        old = lax.dynamic_slice(dG_flat, (0, c0), (NH, C))
-        dG_sc = lax.dynamic_update_slice(dG_flat, old + dG_c, (0, c0))
+            # Re-solve the forward substitution (reference)
+            yv_ref = _fs_yv_ref(A0_chunk, g_cum, b_chunk, v_chunk, active)  # [NH, C, V_pad]
+            yk_ref = _fs_yk_ref(A0_chunk, g_cum, b_chunk, k_chunk_fwd, active)  # [NH, C, K]
+            v_new_ref = yv_ref - jnp.einsum("nck,nkv->ncv", yk_ref, S_prev_chunk)  # [NH, C, V_pad]
 
-        old = lax.dynamic_slice(dB_flat, (0, c0), (NH, C))
-        dB_sc = lax.dynamic_update_slice(dB_flat, old + dB_c, (0, c0))
-        return (dQ_sc, dK_sc, dV_sc, dG_sc, dB_sc, dS_out)
+            # Seeds from the output path: dv_new_out = attn^T @ dY
+            # attn(i,j) = M(i,j) * <q_i, k_j>
+            qk = jnp.einsum("nck,njk->ncj", q_chunk_fwd, k_chunk_fwd)  # [NH, C, C] (i,j)
+            attn = M_full * qk  # [NH, C, C] (i,j)
+            dv_new_out = jnp.einsum("nij,niv->njv", attn, dY_chunk)  # [NH, C, V_pad] = attn^T @ dY
 
-    # fold over chunks in reverse: Nc-1 .. 0
-    def rev_chunks(carry, i):
-        dQ_c, dK_c, dV_c, dG_c, dB_c, dS_in = carry
-        ci = jnp.int32(Nc - 1 - i)
-        dQ_c, dK_c, dV_c, dG_c, dB_c, dS_in = one_chunk(ci, dS_in)
-        return (dQ_c, dK_c, dV_c, dG_c, dB_c, dS_in), None
+            # Carry path: dv_new_carry = (k @ dS_in) * w
+            # NOTE: JIT-safe broadcasting: [:, None] to match [NH, C]
+            w = jnp.exp(g_cum[:, -1][:, None] - g_cum)  # [NH, C]
+            kv_dS = jnp.einsum("nck,nkv->ncv", k_chunk_fwd, dS_in)  # [NH, C, V_pad]
+            dv_new_tot = dv_new_out + kv_dS * w[:, :, None]  # [NH, C, V_pad]
 
-    (dQ_flat, dK_flat, dV_flat, dG_flat, dB_flat, dS0), _ = lax.scan(
-        rev_chunks,
-        (dQ_flat, dK_flat, dV_flat, dG_flat, dB_flat, dS_carry),
+            # Backward-sub seeds for the triangular solves
+            S_prev_T = jnp.transpose(S_prev_chunk, (0, 2, 1))  # [NH, V_pad, K]
+            dyk_out = -jnp.einsum("ncv,nvk->nck", dv_new_out, S_prev_T)  # [NH, C, K]
+            dyv_out = dv_new_out  # [NH, C, V_pad]
+            dyk_tot = -jnp.einsum("ncv,nvk->nck", dv_new_tot, S_prev_T)  # [NH, C, K]
+            dyv_tot = dv_new_tot  # [NH, C, V_pad]
+
+            # Backward-substitution (reference) to RHS and dAbar
+            d_rhs_v_out, dAbar_v_out = _bwd_sub_ref(dyv_out, A0_chunk, g_cum, yv_ref, active)
+            d_rhs_k_out, dAbar_k_out = _bwd_sub_ref(dyk_out, A0_chunk, g_cum, yk_ref, active)
+            d_rhs_v_tot, dAbar_v_tot = _bwd_sub_ref(dyv_tot, A0_chunk, g_cum, yv_ref, active)
+            d_rhs_k_tot, dAbar_k_tot = _bwd_sub_ref(dyk_tot, A0_chunk, g_cum, yk_ref, active)
+
+            # Map RHS(yk) → dK_rhs
+            scale = eg[:, :, None] * b_chunk[:, :, None]  # [NH, C, 1]
+            # dK_rhs_out = scale * d_rhs_k_out  # [NH, C, K]
+            dK_rhs_tot = scale * d_rhs_k_tot  # [NH, C, K]
+
+            # Map dAbar → dA0 (via decay) → dK_A0 (Gram route)
+            # dA0_out = (dAbar_v_out + dAbar_k_out) * decay  # [NH, C, C]
+            dA0_tot = (dAbar_v_tot + dAbar_k_tot) * decay  # [NH, C, C]
+            # dK_A0_out = _gram_bwd_k(dA0_out, b_chunk, k_chunk_fwd, active)  # [NH, C, K]
+            dK_A0_tot = _gram_bwd_k(dA0_tot, b_chunk, k_chunk_fwd, active)  # [NH, C, K]
+
+            # dK_add (carry S_out term)
+            dK_add_ref = jnp.einsum("nkv,ncv->nkc", dS_in, v_new_ref).transpose(0, 2, 1) * w[:, :, None]
+
+            # dK_attn (direct qk path via dAttn)
+            dAttn_ref = jnp.einsum("ncv,nwv->ncw", dY_chunk, v_new_ref)  # [NH, C, C]
+            dK_attn_ref = jnp.einsum("nij,nik->njk", M_full * dAttn_ref, q_chunk_fwd)  # [NH, C, K]
+
+            # Mask ragged rows
+            row_ids = lax.iota(jnp.int32, C)[None, :]  # [1, C]
+            mask_rows = (row_ids < lengths_chunk[:, None])[:, :, None]  # [NH, C, 1]
+            m3 = lambda x: jnp.where(mask_rows, x, 0.0)
+
+            # Compose references
+            dK_ref_tot = m3(dK_attn_ref + dK_rhs_tot + dK_A0_tot + dK_add_ref)
+            dK_cur_m = m3(dK_c_norm)
+
+            # Incremental diffs (TOTAL seeds)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK incr diffs (TOTAL): "
+                "after attn={d1:.3e}  after +rhs={d2:.3e}  after +A0={d3:.3e}  after +add={d4:.3e}",
+                ci=ci,
+                d1=jnp.max(jnp.abs(dK_cur_m - m3(dK_attn_ref))),
+                d2=jnp.max(jnp.abs(dK_cur_m - m3(dK_attn_ref + dK_rhs_tot))),
+                d3=jnp.max(jnp.abs(dK_cur_m - m3(dK_attn_ref + dK_rhs_tot + dK_A0_tot))),
+                d4=jnp.max(jnp.abs(dK_cur_m - dK_ref_tot)),
+            )
+
+            # Final per-term residual checks (TOTAL seeds)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK TOTAL vs REF  max|Δ|={mt:.3e}",
+                ci=ci,
+                mt=jnp.max(jnp.abs(dK_cur_m - dK_ref_tot)),
+            )
+
+        # Scatter per-chunk grads into carried accumulators (kernel space)
+        old = lax.dynamic_slice(dQ_acc, (0, c0, 0), (NH, C, K))
+        dQ_acc = lax.dynamic_update_slice(dQ_acc, old + dQ_c_norm, (0, c0, 0))
+        old = lax.dynamic_slice(dK_acc, (0, c0, 0), (NH, C, K))
+        dK_acc = lax.dynamic_update_slice(dK_acc, old + dK_c_norm, (0, c0, 0))
+        old = lax.dynamic_slice(dV_acc, (0, c0, 0), (NH, C, V_pad))
+        dV_acc = lax.dynamic_update_slice(dV_acc, old + dV_c, (0, c0, 0))
+        old = lax.dynamic_slice(dG_acc, (0, c0), (NH, C))
+        dG_acc = lax.dynamic_update_slice(dG_acc, old + dG_c, (0, c0))
+        old = lax.dynamic_slice(dB_acc, (0, c0), (NH, C))
+        dB_acc = lax.dynamic_update_slice(dB_acc, old + dB_c, (0, c0))
+
+        return (dQ_acc, dK_acc, dV_acc, dG_acc, dB_acc, dS_out), None
+
+    (dQ_flat_norm, dK_flat_norm, dV_flat, dG_flat, dB_flat, dS0), _ = lax.scan(
+        one_chunk,
+        (dQ_flat_norm, dK_flat_norm, dV_flat, dG_flat, dB_flat, dS_carry),
         jnp.arange(Nc, dtype=jnp.int32),
     )
 
-    # ---------- pack back to original layout & trim to L,V ----------
-    # Reconstruct NH-major raw q,k (unpadded), then pad to T_pad to match dQ_flat/dK_flat
-    if head_first:
-        B, H = v_arr.shape[0], v_arr.shape[1] if v_arr.ndim == 4 else (q_arr.shape[0], k_arr.shape[2])
-        # From earlier layout branch, we already have B, L, H, K above
-        q_LK_raw = (jnp.transpose(q_arr, (0, 2, 1, 3))).reshape(aux["NH"], -1, aux["K"]).astype(jnp.float32)
-        k_LK_raw = (jnp.transpose(k_arr, (0, 2, 1, 3))).reshape(aux["NH"], -1, aux["K"]).astype(jnp.float32)
-    else:
-        # q_arr: [B, L, H, K] -> [NH, L, K]
-        NH = aux["NH"]
-        K = aux["K"]
-        L = q_arr.shape[1]
-        q_LK_raw = q_arr.reshape(NH, L, K).astype(jnp.float32)
-        k_LK_raw = k_arr.reshape(NH, L, K).astype(jnp.float32)
-
-    q_raw_flat = _pad_time(q_LK_raw, aux["T_pad"])
-    k_raw_flat = _pad_time(k_LK_raw, aux["T_pad"])
-
+    # ---------- L2‑norm backward: map from normalized space back to raw q,k ----------
     if use_qk_l2norm_in_kernel:
-        eps = jnp.asarray(1e-6, jnp.float32)
-
-        def _l2norm_bwd(dY, X, scale):
-            # d/ dX ( (X / ||X||) * scale ) applied to row-vectors along last dim
-            inv = lax.rsqrt(jnp.sum(X * X, axis=-1, keepdims=True) + eps)
-            dot = jnp.sum(dY * X, axis=-1, keepdims=True)
-            return scale * (inv * dY + (-(inv**3.0)) * X * dot)
-
-        scale_q = jnp.asarray(aux["K"] ** -0.5, jnp.float32)
-        dQ_flat_raw = _l2norm_bwd(dQ_flat, q_raw_flat, scale_q)
-        dK_flat_raw = _l2norm_bwd(dK_flat, k_raw_flat, jnp.asarray(1.0, jnp.float32))
+        scale_q = jnp.asarray(K**-0.5, jnp.float32)
+        dQ_flat_raw = _l2norm_bwd_rows(dQ_flat_norm, q_flat_raw, scale_q)
+        dK_flat_raw = _l2norm_bwd_rows(dK_flat_norm, k_flat_raw, jnp.asarray(1.0, jnp.float32))
     else:
-        # Only the 1/sqrt(K) scaling was applied to q in forward
-        scale_q = jnp.asarray(aux["K"] ** -0.5, jnp.float32)
-        dQ_flat_raw = dQ_flat * scale_q
-        dK_flat_raw = dK_flat
+        scale_q = jnp.asarray(K**-0.5, jnp.float32)
+        dQ_flat_raw = dQ_flat_norm * scale_q
+        dK_flat_raw = dK_flat_norm
 
-    # From here on, use *raw* grads
-    dQ_flat = dQ_flat_raw
-    dK_flat = dK_flat_raw
+    # tiny self-check of the per-row VJP mapping for K (optional)
+    if _DBG:
 
+        def norm_k_row(x):  # y = x / ||x||
+            inv = lax.rsqrt(jnp.sum(x * x) + jnp.asarray(1e-6, x.dtype))
+            return x * inv
+
+        test_rows = jnp.array([0, (NH * T_pad) - 1], dtype=jnp.int32)
+        flat_raw = k_flat_raw.reshape(-1, K)
+        flat_dY = dK_flat_norm.reshape(-1, K)
+
+        def one_row(idx):
+            x = flat_raw[idx]
+            dy = flat_dY[idx]
+            _, vjp_fun = jax.vjp(norm_k_row, x)
+            (dx_vjp,) = vjp_fun(dy)
+            dx_closed = _l2norm_bwd_rows(dy[None, :], x[None, :], jnp.asarray(1.0, jnp.float32))[0]
+            return jnp.max(jnp.abs(dx_vjp - dx_closed))
+
+        diffs = jax.vmap(one_row)(test_rows)
+        jax.debug.print("[GDN dbg] L2 bwd K (VJP vs closed-form) = {d}", d=diffs)
+
+    # ---------- pack back to original layout & trim to L,V ----------
     if head_first:
-        dq = jnp.transpose(dQ_flat.reshape(B, H, T_pad, K)[:, :, :L, :], (0, 2, 1, 3))
-        dk = jnp.transpose(dK_flat.reshape(B, H, T_pad, K)[:, :, :L, :], (0, 2, 1, 3))
+        dq = dQ_flat_raw[:, :L, :].reshape(B, H, L, K)
+        dk = dK_flat_raw[:, :L, :].reshape(B, H, L, K)
+        dv = dV_flat[:, :L, : v_arr.shape[-1]].reshape(B, H, L, v_arr.shape[-1])
+        dg = dG_flat[:, :L].reshape(B, H, L)
+        db = dB_flat[:, :L].reshape(B, H, L)
+    else:
+        dq = jnp.transpose(dQ_flat_raw[:, :L, :].reshape(B, H, L, K), (0, 2, 1, 3))
+        dk = jnp.transpose(dK_flat_raw[:, :L, :].reshape(B, H, L, K), (0, 2, 1, 3))
         dv = jnp.transpose(dV_flat[:, :L, : v_arr.shape[-1]].reshape(B, H, L, v_arr.shape[-1]), (0, 2, 1, 3))
         dg = jnp.transpose(dG_flat[:, :L].reshape(B, H, L), (0, 2, 1))
         db = jnp.transpose(dB_flat[:, :L].reshape(B, H, L), (0, 2, 1))
-    else:
-        dq = dQ_flat[:, :L, :].reshape(B, L, H, K)
-        dk = dK_flat[:, :L, :].reshape(B, L, H, K)
-        dv = dV_flat[:, :L, : v_arr.shape[-1]].reshape(B, L, H, v_arr.shape[-1])
-        dg = dG_flat[:, :L].reshape(B, L, H)
-        db = dB_flat[:, :L].reshape(B, L, H)
 
     d_initial_state = None if initial_state_was_none else dS0.reshape(B, -1, K, V_pad)[:, :H, :, : v_arr.shape[-1]]
     return dq, dk, dv, dg, db, d_initial_state
 
 
-# ---------------------------------------------------------------------------
-# Rematerialized backward for the flash chunk kernel (custom VJP wrapper)
-# ---------------------------------------------------------------------------
-
-# We wrap a *pure arrays* front-end around `_chunk_gated_delta_rule_flash_fused`
-# and give it a custom VJP whose backward recomputes the reference forward and
-# uses JAX's VJP to obtain gradients. This avoids saving large per-token
-# intermediates from the flash forward (T, W/U, etc.).
-#
-# Notes:
-# - All non-differentiable flags are marked static via `nondiff_argnums`.
-# - We ignore d(final_state) in backward (it's not used in training prefill);
-#   if you want gradients wrt initial_state in the future, wire a second VJP
-#   with a reverse scan over the chunk bridge.
-#
+# ---------- custom VJP wrapper (unchanged signatures) ----------
 
 
 @functools.partial(
     jax.custom_vjp,
-    nondiff_argnums=(
-        8,  # chunk_size
-        9,  # output_final_state
-        10,  # use_qk_l2norm_in_kernel
-        11,  # head_first
-        12,  # use_varlen
-    ),
+    nondiff_argnums=(8, 9, 10, 11, 12),
 )
 def _chunk_gated_delta_rule_flash(
     q_arr,
@@ -2279,7 +2545,7 @@ def _chunk_gated_delta_rule_flash(
         lengths=lengths,
         offsets=offsets,
         use_varlen=use_varlen,
-        save_for_backward=False,  # plain call (used by export or when no grads)
+        save_for_backward=False,
     )
     return (out_arr, final_state)
 
@@ -2313,9 +2579,8 @@ def _chunk_gated_delta_rule_flash_call_fwd(
         lengths=lengths,
         offsets=offsets,
         use_varlen=use_varlen,
-        save_for_backward=True,  # <-- save A0/S_prev for bwd
+        save_for_backward=True,
     )
-    # Residuals for bwd (arrays only; no Python captures)
     initial_state_was_none = initial_state is None
     res = (q_arr, k_arr, v_arr, g_arr, beta_arr, lengths, head_first, initial_state_was_none, aux)
     return (out_arr, final_state), res
@@ -2331,8 +2596,7 @@ def _chunk_gated_delta_rule_flash_call_bwd(
     cotangents,
 ):
     q_arr, k_arr, v_arr, g_arr, beta_arr, lengths, head_first_res, initial_state_was_none, aux = res
-    d_out_arr, _d_final_state = cotangents  # we ignore d(final_state)
-
+    d_out_arr, _d_final_state = cotangents
     dq, dk, dv, dg, db, dS0 = _chunk_gated_delta_rule_flash_bwd_fused(
         q_arr,
         k_arr,
@@ -2346,8 +2610,6 @@ def _chunk_gated_delta_rule_flash_call_bwd(
         initial_state_was_none=initial_state_was_none,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
     )
-
-    # Match primal differentiable args: (q, k, v, g, beta, lengths, offsets, initial_state)
     d_lengths = None
     d_offsets = None
     d_initial_state = None if initial_state_was_none else dS0

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -688,43 +688,22 @@ def recurrent_gated_delta_rule(
 recurrent_gated_delta_rule.__doc__ = _recurrent_gated_delta_rule_reference.__doc__
 
 
-def chunk_gated_delta_rule(
-    query: NamedArray,  # [batch, position, heads, k_head_dim]
-    key: NamedArray,  # [batch, position, heads, k_head_dim]
-    value: NamedArray,  # [batch, position, heads, v_head_dim]
-    g: NamedArray,  # [batch, position, heads]  (log-decay; α=exp(g))
-    beta: NamedArray,  # [batch, position, heads]  (β)
+def _prepare_chunk_inputs(
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    g: NamedArray,
+    beta: NamedArray,
     *,
-    chunk_size: int = 64,
-    initial_state: Optional[jnp.ndarray] = None,  # (B,H,dk,dv)
-    output_final_state: bool = False,
-    use_qk_l2norm_in_kernel: bool = True,
-    use_flash: bool = True,
-) -> tuple[NamedArray, Optional[jnp.ndarray]]:
-    """Chunkwise-parallel GDN (DeltaNet UT/WY extended with decay).
-
-    High-level sketch (per head):
-      1) Split the length-L sequence into Nc = ceil(L/C) chunks of size C.
-      2) Inside each chunk, form a strictly lower-triangular operator encoding
-         the rank-1 updates and the *relative decays* between positions.
-      3) Compute T = (I - A)^{-1} via *forward substitution*.
-      4) Obtain "pseudo values" U = T (β V) and a decayed key summary K̂ = T (β K ⊙ exp(g)).
-      5) Bridge chunks with the cross-chunk state S (decayed carry and innovation).
-      6) Produce outputs by combining inter-chunk (from S) and intra-chunk terms.
-    """
-
-    if use_flash:
-        # Flash-optimized chunk kernel will be added in a follow-up change.
-        # For now we intentionally fall back to the reference implementation.
-        pass
-    # ---- axes ----
+    chunk_size: int,
+    use_qk_l2norm_in_kernel: bool,
+):
     Batch = query.resolve_axis("batch")
     Pos = query.resolve_axis("position")
     Heads = query.resolve_axis("heads")
     Dk = query.resolve_axis("k_head_dim")
     Dv = value.resolve_axis("v_head_dim")
 
-    # ---- promote & normalize ----
     q = query.astype(jnp.float32)
     k = key.astype(jnp.float32)
     v = value.astype(jnp.float32)
@@ -736,7 +715,6 @@ def chunk_gated_delta_rule(
         k = _l2norm(k, axis=Dk)
     q = q * (Dk.size**-0.5)
 
-    # ---- pad to multiple of chunk_size ----
     L = Pos.size
     pad = (chunk_size - (L % chunk_size)) % chunk_size
     if pad > 0:
@@ -752,7 +730,6 @@ def chunk_gated_delta_rule(
     Chunks = Axis("chunks", Nc)
     C = Axis("chunk", chunk_size)
 
-    # Helper to reshape [B, Lpad, H, d] → [B, Nc, C, H, d]
     def _chunk(x: NamedArray) -> NamedArray:
         return x.unflatten_axis(PosPad, (Chunks, C))
 
@@ -761,6 +738,78 @@ def chunk_gated_delta_rule(
     v_c = _chunk(v)
     b_c = _chunk(b)
     g_c = _chunk(gg)
+
+    return {
+        "q_c": q_c,
+        "k_c": k_c,
+        "v_c": v_c,
+        "b_c": b_c,
+        "g_c": g_c,
+        "Batch": Batch,
+        "Pos": Pos,
+        "PosPad": PosPad,
+        "Heads": Heads,
+        "Dk": Dk,
+        "Dv": Dv,
+        "Chunks": Chunks,
+        "Chunk": C,
+        "pad": pad,
+    }
+
+
+def _chunk_gated_delta_rule_reference(
+    query: NamedArray,  # [batch, position, heads, k_head_dim]
+    key: NamedArray,  # [batch, position, heads, k_head_dim]
+    value: NamedArray,  # [batch, position, heads, v_head_dim]
+    g: NamedArray,  # [batch, position, heads]  (log-decay; α=exp(g))
+    beta: NamedArray,  # [batch, position, heads]  (β)
+    *,
+    chunk_size: int = 64,
+    initial_state: Optional[jnp.ndarray] = None,  # (B,H,dk,dv)
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+) -> tuple[NamedArray, Optional[jnp.ndarray]]:
+    """Chunkwise-parallel GDN (DeltaNet UT/WY extended with decay).
+
+    High-level sketch (per head):
+      1) Split the length-L sequence into Nc = ceil(L/C) chunks of size C.
+      2) Inside each chunk, form a strictly lower-triangular operator encoding
+         the rank-1 updates and the *relative decays* between positions.
+      3) Compute T = (I - A)^{-1} via *forward substitution*.
+      4) Obtain "pseudo values" U = T (β V) and a decayed key summary K̂ = T (β K ⊙ exp(g)).
+      5) Bridge chunks with the cross-chunk state S (decayed carry and innovation).
+      6) Produce outputs by combining inter-chunk (from S) and intra-chunk terms.
+    """
+
+    # ---- axes ----
+    prepared = _prepare_chunk_inputs(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    q_c = prepared["q_c"]
+    k_c = prepared["k_c"]
+    v_c = prepared["v_c"]
+    b_c = prepared["b_c"]
+    g_c = prepared["g_c"]
+    Batch = prepared["Batch"]
+    Pos = prepared["Pos"]
+    PosPad = prepared["PosPad"]
+    Heads = prepared["Heads"]
+    Dk = prepared["Dk"]
+    Dv = prepared["Dv"]
+    Chunks = prepared["Chunks"]
+    C = prepared["Chunk"]
+    # pad = prepared["pad"]
+
+    Nc = Chunks.size
+    # Lt = PosPad.size
+    L = Pos.size
 
     v_beta = v_c * b_c.broadcast_axis(Dv)  # βV per position
     k_beta = k_c * b_c.broadcast_axis(Dk)  # βK per position
@@ -842,7 +891,8 @@ def chunk_gated_delta_rule(
     g_bhcc = hax.rearrange(g_cum, (Batch, Heads, Chunks, C)).array
 
     B_, H_, dk_, dv_ = Batch.size, Heads.size, Dk.size, Dv.size
-    S = jnp.zeros((B_, H_, dk_, dv_), dtype=v.dtype) if initial_state is None else initial_state.astype(v.dtype)
+    v_dtype = v_c.dtype
+    S = jnp.zeros((B_, H_, dk_, dv_), dtype=v_dtype) if initial_state is None else initial_state.astype(v_dtype)
 
     # Strict upper mask (i<j) to zero invalid future positions within a chunk
     mask_strict_upper = jnp.triu(jnp.ones((C.size, C.size), dtype=bool), k=1)
@@ -896,6 +946,535 @@ def chunk_gated_delta_rule(
     _dbg("chunk/out", out_final.array)
 
     return (out_final, S) if output_final_state else (out_final, None)
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+@dataclass(frozen=True)
+class _Tiles:
+    BK: int = 64
+    BV: int = 64
+
+
+def _pick_tiles(dk: int, dv: int) -> _Tiles:
+    bk = 64 if dk >= 128 else 32
+    bv = 64 if dv >= 128 else 32
+    return _Tiles(BK=bk, BV=bv)
+
+
+def _pad_L_axis(x: jnp.ndarray, width: int) -> jnp.ndarray:
+    if width <= 0:
+        return x
+    if x.ndim == 2:  # [NH, L]
+        return jnp.pad(x, ((0, 0), (0, width)))
+    elif x.ndim == 3:  # [NH, L, D]
+        return jnp.pad(x, ((0, 0), (0, width), (0, 0)))
+    elif x.ndim == 4:  # [B, H, L, D]
+        return jnp.pad(x, ((0, 0), (0, 0), (0, width), (0, 0)))
+    else:
+        raise ValueError(f"Unexpected rank for length-padding: {x.ndim}")
+
+
+def _gdn_chunk_fwd_kernel(
+    q_ref,  # [NH, T_pad, K]
+    k_ref,  # [NH, T_pad, K]
+    v_ref,  # [NH, T_pad, V]
+    g_ref,  # [NH, T_pad]
+    beta_ref,  # [NH, T_pad]
+    init_ref,  # [NH, K, V]
+    lengths_ref,  # [NH]  (real lengths, but we rely on zero padding)
+    out_ref,  # [NH, T_pad, V]
+    final_ref,  # [NH, K, V]
+    *,
+    T_pad: int,
+    K: int,
+    V: int,
+    chunk_len: int,
+    head_first: bool,
+    store_final_state: bool,
+    use_qk_l2norm_in_kernel: bool,
+    BK: int,
+    BV: int,
+):
+    nh = pl.program_id(axis=0)
+
+    # Per-(seq,head) views (depend on refs → no capture)
+    q_view = q_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, K)][0]
+    k_view = k_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, K)][0]
+    v_view = v_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, V)][0]
+    g_view = g_ref[dslice(nh, 1), dslice(0, T_pad)][0]
+    b_view = beta_ref[dslice(nh, 1), dslice(0, T_pad)][0]
+
+    # FP32 state S
+    S = init_ref[dslice(nh, 1), dslice(0, K), dslice(0, V)][0].astype(jnp.float32)
+
+    # “zero” scratch derived from inputs (no captured zero)
+    out_tile = v_view * (g_view[:, None] - g_view[:, None])  # [T_pad, V], all zeros
+
+    # 1/sqrt(K) passed as kwarg would be nice, but this constant is tiny and stable
+    # Make it an input-like traced scalar: multiply sum-by-sum to get 1 then divide by sqrt(K)
+    # However, to keep things simple and JAX-friendly, do this:
+    scale = jnp.asarray(1.0 / jnp.sqrt(K), dtype=jnp.float32)
+
+    nchunks_max = T_pad // chunk_len
+
+    def chunk_body(c_idx, carry):
+        S_carry, out_tile_carry = carry
+        # dynamic indices only: derive zero from c_start
+        c_start = c_idx * chunk_len
+        zero_col_dyn = c_start - c_start
+
+        # Fixed-size chunk slices
+        q_c = lax.dynamic_slice(q_view, (c_start, zero_col_dyn), (chunk_len, K)).astype(jnp.float32)
+        k_c = lax.dynamic_slice(k_view, (c_start, zero_col_dyn), (chunk_len, K)).astype(jnp.float32)
+        v_c = lax.dynamic_slice(v_view, (c_start, zero_col_dyn), (chunk_len, V)).astype(jnp.float32)
+        g_c = lax.dynamic_slice(g_view, (c_start,), (chunk_len,)).astype(jnp.float32)
+        b_c = lax.dynamic_slice(b_view, (c_start,), (chunk_len,)).astype(jnp.float32)
+
+        # Optional L2-norm + scale
+        if use_qk_l2norm_in_kernel:
+            qn = jnp.sqrt(jnp.sum(q_c * q_c, axis=1, keepdims=True) + 1e-6)
+            kn = jnp.sqrt(jnp.sum(k_c * k_c, axis=1, keepdims=True) + 1e-6)
+            q_c = q_c / jnp.where(qn > 0, qn, 1.0)
+            k_c = k_c / jnp.where(kn > 0, kn, 1.0)
+        q_c = q_c * scale
+
+        # Chunkwise cumsum/exp
+        g_cum = jnp.cumsum(g_c, axis=0)  # (C,)
+        eg_cum = jnp.exp(g_cum)  # (C,)
+
+        v_beta = v_c * b_c[:, None]  # (C,V)
+        k_beta = k_c * b_c[:, None]  # (C,K)
+
+        # UT buffers as "zeros" from inputs
+        yv = v_c * (g_c[:, None] - g_c[:, None])  # (C,V)
+        yk = k_c * (g_c[:, None] - g_c[:, None])  # (C,K)
+
+        def ut_row_update(i, carry_ut):
+            yv_cur, yk_cur = carry_ut
+
+            # accumulate over j < i
+            def acc_j(j, acc):
+                acc_v, acc_k = acc
+                dot_ij = jnp.dot(k_beta[i], k_c[j])
+                coeff = -dot_ij * jnp.exp(g_cum[i] - g_cum[j])
+                acc_v = acc_v + coeff * yv_cur[j]
+                acc_k = acc_k + coeff * yk_cur[j]
+                return (acc_v, acc_k)
+
+            zero_v = v_c[0] * (g_c[0] - g_c[0])
+            zero_k = k_c[0] * (g_c[0] - g_c[0])
+            acc_v, acc_k = lax.fori_loop(0, i, acc_j, (zero_v, zero_k))
+            yv_cur = yv_cur.at[i].set(v_beta[i] + acc_v)
+            yk_cur = yk_cur.at[i].set(k_beta[i] * eg_cum[i] + acc_k)
+            return (yv_cur, yk_cur)
+
+        # device loop over rows
+        yv, yk = lax.fori_loop(0, chunk_len, ut_row_update, (yv, yk))
+
+        # ---- bridge with cross-chunk S and compute outputs ----
+        qexp = q_c * eg_cum[:, None]
+        v_prime = yk @ S_carry
+        inter = qexp @ S_carry
+
+        # lower-triangular (incl. diagonal) attention-like term (vectorized)
+        attn_raw = (q_c @ k_c.T) * jnp.exp(g_cum[:, None] - g_cum[None, :])
+        idx_i = lax.broadcasted_iota(jnp.int32, (chunk_len, chunk_len), 0)
+        idx_j = lax.broadcasted_iota(jnp.int32, (chunk_len, chunk_len), 1)
+        zero_scalar = jnp.sum(g_c[:1] - g_c[:1])
+        attn = jnp.where(idx_i >= idx_j, attn_raw, zero_scalar)
+        v_new = yv - v_prime
+        out_chunk = inter + attn @ v_new
+
+        # write chunk result
+        out_tile_next = lax.dynamic_update_slice(
+            out_tile_carry, out_chunk.astype(out_ref.dtype), (c_start, zero_col_dyn)
+        )
+
+        # ---- Update S ----
+        g_tail = jnp.sum(g_c, axis=0)
+        decay_tail = jnp.exp(g_tail)
+        S_carry = S_carry * decay_tail
+        dw_full = jnp.exp(g_tail - g_cum)
+        k_scaled = k_c * dw_full[:, None]
+        S_carry = S_carry + k_scaled.T @ v_new
+
+        return (S_carry, out_tile_next)
+
+    S, out_tile = lax.fori_loop(0, nchunks_max, chunk_body, (S, out_tile))
+
+    # final writes (add singleton to match NDIndexer slice)
+    out_ref[dslice(nh, 1), dslice(0, T_pad), dslice(0, V)] = out_tile[None, :, :]
+    if store_final_state:
+        final_ref[dslice(nh, 1), dslice(0, K), dslice(0, V)] = S.astype(final_ref.dtype)[None, :, :]
+
+
+def _chunk_gated_delta_rule_flash_tiled(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    *,
+    chunk_size: int = 64,
+    initial_state: Optional[jnp.ndarray] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    head_first: bool = False,
+    offsets: Optional[jnp.ndarray] = None,
+):
+    if not head_first:
+        Batch = query.resolve_axis("batch")
+        Pos = query.resolve_axis("position")
+        Heads = query.resolve_axis("heads")
+        Dk = query.resolve_axis("k_head_dim")
+        Dv = value.resolve_axis("v_head_dim")
+        B_, L_, H_, K_ = Batch.size, Pos.size, Heads.size, Dk.size
+        V_ = Dv.size
+        NH = B_ * H_
+
+        q_bhlk = hax.rearrange(query, (Batch, Heads, Pos, Dk)).array
+        k_bhlk = hax.rearrange(key, (Batch, Heads, Pos, Dk)).array
+        v_bhlv = hax.rearrange(value, (Batch, Heads, Pos, Dv)).array
+        g_bhl = hax.rearrange(g, (Batch, Heads, Pos)).array
+        b_bhl = hax.rearrange(beta, (Batch, Heads, Pos)).array
+    else:
+        Batch = query.resolve_axis("batch")
+        Heads = query.resolve_axis("heads")
+        Pos = query.resolve_axis("position")
+        Dk = query.resolve_axis("k_head_dim")
+        Dv = value.resolve_axis("v_head_dim")
+        B_, H_, L_, K_ = Batch.size, Heads.size, Pos.size, Dk.size
+        V_ = Dv.size
+        NH = B_ * H_
+        q_bhlk = query.array
+        k_bhlk = key.array
+        v_bhlv = value.array
+        g_bhl = g.array
+        b_bhl = beta.array
+
+    q_flat = q_bhlk.reshape(NH, L_, K_)
+    k_flat = k_bhlk.reshape(NH, L_, K_)
+    v_flat = v_bhlv.reshape(NH, L_, V_)
+    g_flat = g_bhl.reshape(NH, L_)
+    b_flat = b_bhl.reshape(NH, L_)
+
+    lengths = (
+        jnp.full((NH,), L_, dtype=jnp.int32)
+        if offsets is None
+        else (offsets.astype(jnp.int32)[1:] - offsets.astype(jnp.int32)[:-1])
+    )
+
+    T_pad = int(_ceil_div(L_, chunk_size) * chunk_size)
+    pad_amt = T_pad - L_
+    q_flat = _pad_L_axis(q_flat, pad_amt)
+    k_flat = _pad_L_axis(k_flat, pad_amt)
+    v_flat = _pad_L_axis(v_flat, pad_amt)
+    g_flat = _pad_L_axis(g_flat, pad_amt)
+    b_flat = _pad_L_axis(b_flat, pad_amt)
+
+    init_flat = (
+        jnp.zeros((NH, K_, V_), dtype=jnp.float32)
+        if initial_state is None
+        else initial_state.reshape(NH, K_, V_).astype(jnp.float32)
+    )
+
+    tiles = _pick_tiles(K_, V_)
+    BK, BV = int(tiles.BK), int(tiles.BV)
+
+    out_struct = jax.ShapeDtypeStruct((NH, T_pad, V_), value.dtype)
+    final_struct = jax.ShapeDtypeStruct((NH, K_, V_), jnp.float32)
+
+    kernel_partial = functools.partial(
+        _gdn_chunk_fwd_kernel,
+        T_pad=T_pad,
+        K=K_,
+        V=V_,
+        chunk_len=int(chunk_size),
+        head_first=head_first,
+        store_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        BK=BK,
+        BV=BV,
+    )
+
+    out_flat, final_flat = pl.pallas_call(
+        kernel_partial,
+        out_shape=(out_struct, final_struct),
+        grid=(NH,),
+        in_specs=(
+            pl.BlockSpec((1, T_pad, K_), lambda bid: (bid, 0, 0)),
+            pl.BlockSpec((1, T_pad, K_), lambda bid: (bid, 0, 0)),
+            pl.BlockSpec((1, T_pad, V_), lambda bid: (bid, 0, 0)),
+            pl.BlockSpec((1, T_pad), lambda bid: (bid, 0)),
+            pl.BlockSpec((1, T_pad), lambda bid: (bid, 0)),
+            pl.BlockSpec((1, K_, V_), lambda bid: (bid, 0, 0)),
+            pl.BlockSpec((1,), lambda bid: (bid,)),  # lengths
+        ),
+        out_specs=(
+            pl.BlockSpec((1, T_pad, V_), lambda bid: (bid, 0, 0)),
+            pl.BlockSpec((1, K_, V_), lambda bid: (bid, 0, 0)),
+        ),
+        interpret=_should_interpret_pallas(),
+    )(q_flat, k_flat, v_flat, g_flat, b_flat, init_flat, lengths)
+
+    out_trim = out_flat[:, :L_, :]
+    if not head_first:
+        out_bhLv = out_trim.reshape(B_, H_, L_, V_)
+        out_named = hax.named(out_bhLv, (Batch, Heads, Pos, Dv))
+        out_final = hax.rearrange(out_named, (Batch, Pos, Heads, Dv))
+        final = final_flat.reshape(B_, H_, K_, V_) if output_final_state else None
+        return out_final, final
+    else:
+        out_bHLv = out_trim.reshape(B_, H_, L_, V_)
+        out_named = hax.named(out_bHLv, (Batch, Heads, Pos, Dv))
+        final = final_flat.reshape(B_, H_, K_, V_) if output_final_state else None
+        return out_named, final
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(6, 7, 8, 9, 10, 11))
+def _chunk_gdn_flash_array(
+    q_arr: jnp.ndarray,  # [B,L,H,K] or [B,H,L,K]
+    k_arr: jnp.ndarray,
+    v_arr: jnp.ndarray,
+    g_arr: jnp.ndarray,  # [B,L,H] or [B,H,L]
+    beta_arr: jnp.ndarray,  # [B,L,H] or [B,H,L]
+    initial_state: Optional[jnp.ndarray],  # [B,H,K,V]
+    chunk_size: int,
+    output_final_state: bool,
+    use_qk_l2norm_in_kernel: bool,
+    head_first: bool,
+    use_varlen: bool,
+    offsets: Optional[jnp.ndarray],
+):
+    if not head_first:
+        Batch = Axis("batch", q_arr.shape[0])
+        Pos = Axis("position", q_arr.shape[1])
+        Heads = Axis("heads", q_arr.shape[2])
+        Dk = Axis("k_head_dim", q_arr.shape[3])
+        Dv = Axis("v_head_dim", v_arr.shape[3])
+        q = hax.named(q_arr, (Batch, Pos, Heads, Dk))
+        k = hax.named(k_arr, (Batch, Pos, Heads, Dk))
+        v = hax.named(v_arr, (Batch, Pos, Heads, Dv))
+        gg = hax.named(g_arr, (Batch, Pos, Heads))
+        bb = hax.named(beta_arr, (Batch, Pos, Heads))
+    else:
+        Batch = Axis("batch", q_arr.shape[0])
+        Heads = Axis("heads", q_arr.shape[1])
+        Pos = Axis("position", q_arr.shape[2])
+        Dk = Axis("k_head_dim", q_arr.shape[3])
+        Dv = Axis("v_head_dim", v_arr.shape[3])
+        q = hax.named(q_arr, (Batch, Heads, Pos, Dk))
+        k = hax.named(k_arr, (Batch, Heads, Pos, Dk))
+        v = hax.named(v_arr, (Batch, Heads, Pos, Dv))
+        gg = hax.named(g_arr, (Batch, Heads, Pos))
+        bb = hax.named(beta_arr, (Batch, Heads, Pos))
+
+    out_named, final = _chunk_gated_delta_rule_flash_tiled(
+        q,
+        k,
+        v,
+        gg,
+        bb,
+        chunk_size=chunk_size,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        head_first=head_first,
+        offsets=offsets if use_varlen else None,
+    )
+    return out_named.array, final
+
+
+def _chunk_gdn_flash_array_fwd(
+    q_arr,
+    k_arr,
+    v_arr,
+    g_arr,
+    beta_arr,
+    initial_state,
+    chunk_size,
+    output_final_state,
+    use_qk_l2norm_in_kernel,
+    head_first,
+    use_varlen,
+    offsets,
+):
+    out_arr, final = _chunk_gdn_flash_array(
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        initial_state,
+        chunk_size,
+        output_final_state,
+        use_qk_l2norm_in_kernel,
+        head_first,
+        use_varlen,
+        offsets,
+    )
+    residual = (
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        initial_state,
+        chunk_size,
+        use_qk_l2norm_in_kernel,
+        head_first,
+        use_varlen,
+        offsets,
+    )
+    return (out_arr, final), residual
+
+
+def _chunk_gdn_flash_array_bwd(
+    chunk_size,
+    output_final_state,
+    use_qk_l2norm_in_kernel,
+    head_first,
+    use_varlen,
+    offsets,
+    residual,
+    tangents,
+):
+    (
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        init_arr,
+        chunk_size_res,
+        use_norm_res,
+        head_first_res,
+        use_varlen_res,
+        offsets_res,
+    ) = residual
+    dout, dfinal = tangents
+
+    # Rematerialize via reference kernel for VJP (memory friendly and already parity-checked)
+    Batch = Axis("batch", q_arr.shape[0])
+    if not head_first_res:
+        Pos = Axis("position", q_arr.shape[1])
+        Heads = Axis("heads", q_arr.shape[2])
+        Dk = Axis("k_head_dim", q_arr.shape[3])
+        Dv = Axis("v_head_dim", v_arr.shape[3])
+        qn = hax.named(q_arr, (Batch, Pos, Heads, Dk))
+        kn = hax.named(k_arr, (Batch, Pos, Heads, Dk))
+        vn = hax.named(v_arr, (Batch, Pos, Heads, Dv))
+        gn = hax.named(g_arr, (Batch, Pos, Heads))
+        bn = hax.named(beta_arr, (Batch, Pos, Heads))
+    else:
+        Heads = Axis("heads", q_arr.shape[1])
+        Pos = Axis("position", q_arr.shape[2])
+        Dk = Axis("k_head_dim", q_arr.shape[3])
+        Dv = Axis("v_head_dim", v_arr.shape[3])
+        qn = hax.named(q_arr, (Batch, Heads, Pos, Dk))
+        kn = hax.named(k_arr, (Batch, Heads, Pos, Dk))
+        vn = hax.named(v_arr, (Batch, Heads, Pos, Dv))
+        gn = hax.named(g_arr, (Batch, Heads, Pos))
+        bn = hax.named(beta_arr, (Batch, Heads, Pos))
+
+    def _ref_fun(q_in, k_in, v_in, g_in, beta_in, init_in):
+        out_ref, fin_ref = _chunk_gated_delta_rule_reference(
+            q_in,
+            k_in,
+            v_in,
+            g_in,
+            beta_in,
+            chunk_size=chunk_size_res,
+            initial_state=init_in,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=use_norm_res,
+        )
+        return out_ref.array, fin_ref
+
+    init_default = (
+        init_arr
+        if init_arr is not None
+        else jnp.zeros((q_arr.shape[0], q_arr.shape[2], q_arr.shape[3], v_arr.shape[3]), dtype=jnp.float32)
+    )
+    _, vjp_fun = jax.vjp(_ref_fun, qn, kn, vn, gn, bn, init_default)
+    dout_arr = dout if not isinstance(dout, NamedArray) else dout.array
+    dfinal_arr = jnp.zeros_like(init_default) if dfinal is None else dfinal
+    gq, gk, gv, gg, gb, ginit = vjp_fun((dout_arr, dfinal_arr))
+
+    return (
+        gq.array if isinstance(gq, NamedArray) else gq,
+        gk.array if isinstance(gk, NamedArray) else gk,
+        gv.array if isinstance(gv, NamedArray) else gv,
+        gg.array if isinstance(gg, NamedArray) else gg,
+        gb.array if isinstance(gb, NamedArray) else gb,
+        (None if init_arr is None else ginit),
+    )
+
+
+_chunk_gdn_flash_array.defvjp(_chunk_gdn_flash_array_fwd, _chunk_gdn_flash_array_bwd)
+
+
+def chunk_gated_delta_rule(
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    g: NamedArray,
+    beta: NamedArray,
+    chunk_size: int = 64,
+    initial_state: Optional[jnp.ndarray] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_flash: bool = True,
+    *,
+    head_first: bool = False,
+    offsets: Optional[jnp.ndarray] = None,
+    use_varlen: bool = False,
+) -> tuple[NamedArray, Optional[jnp.ndarray]]:
+    if use_flash:
+        out_arr, fin = _chunk_gdn_flash_array(
+            query.array,
+            key.array,
+            value.array,
+            g.array,
+            beta.array,
+            initial_state,
+            chunk_size,
+            output_final_state,
+            use_qk_l2norm_in_kernel,
+            head_first,
+            use_varlen,
+            offsets,
+        )
+        out_named = hax.named(
+            out_arr,
+            (
+                value.axes
+                if not head_first
+                else (
+                    query.resolve_axis("batch"),
+                    query.resolve_axis("heads"),
+                    query.resolve_axis("position"),
+                    value.resolve_axis("v_head_dim"),
+                )
+            ),
+        )
+        return out_named, fin
+
+    # reference fallback
+    return _chunk_gated_delta_rule_reference(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
 
 
 # ---------- Layer ----------

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -1992,7 +1992,8 @@ def _gdn_chunk_bwd_kernel_fused(
     dQ_attn_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dQ_attn[None, None, :, :]
     dQ_inter_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dQ_inter[None, None, :, :]
     dK_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_tile[None, None, :, :]
-    dV_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, BV)] = dV_tile[None, None, :, :]
+    # dV_tile_ref shape: [NH, 1, C, BV] — index C then BV
+    dV_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, BV)] = dV_tile[None, None, :, :]
     dG_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dG_tile[None, None, :]
     dB_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dB_tile[None, None, :]
     dS_out_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)] = dS_out[None, :, :]
@@ -3018,6 +3019,7 @@ class GatedDeltaNet(eqx.Module):
     """
 
     config: GatedDeltaNetConfig = eqx.field(static=True)
+    use_flash: bool = eqx.field(static=True)
 
     # projections
     in_proj_qkvz: hnn.Linear  # [Embed] -> [Q|K|V|Z]
@@ -3036,7 +3038,7 @@ class GatedDeltaNet(eqx.Module):
     out_proj: hnn.Linear  # [Heads, VHeadDim] -> [Embed]
 
     @staticmethod
-    def init(config: GatedDeltaNetConfig, *, key) -> "GatedDeltaNet":
+    def init(config: GatedDeltaNetConfig, *, use_flash: bool = True, key) -> "GatedDeltaNet":
         """Initializer mirrors the HF defaults: no biases in projections/out_proj;
         A_log ~ log U(0,16), dt_bias = 1, small conv kernel."""
         k_qkvz, k_ba, k_conv, k_out = jax.random.split(key, 4)
@@ -3072,7 +3074,7 @@ class GatedDeltaNet(eqx.Module):
         )
         dt_bias = hax.named(jnp.ones((config.Heads.size,), dtype=jnp.float32), (config.Heads.name,))
 
-        o_norm = FusedRMSNormGated.init(config.VHeadDim, eps=config.rms_norm_eps)
+        o_norm = FusedRMSNormGated.init(config.VHeadDim, eps=config.rms_norm_eps, use_flash=use_flash)
         out_proj = hnn.Linear.init(
             In=(config.Heads, config.VHeadDim), Out=config.Embed, out_first=True, use_bias=False, key=k_out
         )
@@ -3086,6 +3088,7 @@ class GatedDeltaNet(eqx.Module):
             dt_bias=dt_bias,
             o_norm=o_norm,
             out_proj=out_proj,
+            use_flash=use_flash,
         )
 
     def _fix_qkvz_ordering(
@@ -3285,6 +3288,7 @@ class GatedDeltaNet(eqx.Module):
                 initial_state=S_state,
                 output_final_state=True,
                 use_qk_l2norm_in_kernel=True,
+                use_flash=self.use_flash,
             )
         else:
             out_bphd, S_new = chunk_gated_delta_rule(
@@ -3297,6 +3301,7 @@ class GatedDeltaNet(eqx.Module):
                 initial_state=None,
                 output_final_state=inference,
                 use_qk_l2norm_in_kernel=True,
+                use_flash=self.use_flash,
             )
 
         # Keep the kernel output on "heads" so TP can shard the out-projection.
@@ -3370,6 +3375,13 @@ class GatedDeltaNet(eqx.Module):
         )
 
     @classmethod
-    def from_state_dict(cls, config: GatedDeltaNetConfig, state: dict[str, jnp.ndarray], *, key) -> "GatedDeltaNet":
-        layer = cls.init(config, key=key)
+    def from_state_dict(
+        cls,
+        config: GatedDeltaNetConfig,
+        state: dict[str, jnp.ndarray],
+        use_flash: bool = True,
+        *,
+        key,
+    ) -> "GatedDeltaNet":
+        layer = cls.init(config, key=key, use_flash=use_flash)
         return layer.load_state_dict(state)

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -46,11 +46,11 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, NamedArray
 
-_GDN_DBG = bool(int(os.environ.get("GDN_DEBUG_SHARDING", "0")))
+_GDN_DBG_SHARDING = bool(int(os.environ.get("GDN_DEBUG_SHARDING", "0")))
 
 
 def _dbg(tag: str, arr):
-    if not _GDN_DBG:
+    if not _GDN_DBG_SHARDING:
         return
     try:
         jax.debug.inspect_array_sharding(arr, callback=lambda s: print(f"[GDN][internal] {tag}: {s}"))
@@ -1670,6 +1670,11 @@ def _gdn_chunk_bwd_kernel_fused(
     dG_chunk_ref,  # [NH, 1, C]
     dB_chunk_ref,  # [NH, 1, C]
     dS_out_tile_ref,  # [NH, K, BV]
+    dK_attn_only_ref,  # [NH, 1, C, K]
+    dK_rhs_only_ref,  # [NH, 1, C, K]
+    dK_A0_only_ref,  # [NH, 1, C, K]
+    dK_add_only_ref,  # [NH, 1, C, K]
+    d_rhs_k_only_ref,  # [NH, 1, C, K]
     *,
     C: int,
     K: int,
@@ -1778,9 +1783,12 @@ def _gdn_chunk_bwd_kernel_fused(
     W = (qk * dAttn) * decay * tril  # [C, C]
     dgc_attn = jnp.sum(W, axis=1) - jnp.sum(W, axis=0)  # [C]
 
-    # Inter term
+    # Inter term (out_i += (q_i * e^{g_cum_i})^T S_prev)
     dQ_inter = (dY @ jnp.transpose(S_prev)) * eg[:, None]  # [C, K]
     dS_prev_local = jnp.transpose(q_c * eg[:, None]) @ dY  # [K, BV]
+    # g from "inter":  d/d g_cum[i] inter_i = <dY_i, S_prev^T q_i> * e^{g_cum[i]}
+    inter_base = q_c @ S_prev  # [C, BV]
+    dgc_inter = eg * jnp.sum(inter_base * dY, axis=-1)  # [C]
 
     # -------------------------------------------------------------------------
     # v_new path
@@ -1808,31 +1816,35 @@ def _gdn_chunk_bwd_kernel_fused(
     #   d_rhs_v ∈ ℝ^{C×BV}, dAbar_v ∈ ℝ^{C×C}
     #   d_rhs_k ∈ ℝ^{C×K},  dAbar_k ∈ ℝ^{C×C}
     # -------------------------------------------------------------------------
-    def bwd_sub(dy, width, is_vec_rhs):
-        # dy: [C, width]; returns (d_rhs: [C, width], dAbar: [C, C])
+    def bwd_sub(dy, Y_fwd):
+        # dy:    [C, width]
+        # Y_fwd: [C, width]
+        # returns (d_rhs: [C, width], dAbar: [C, C])
+        width = Y_fwd.shape[1]
         d_rhs = jnp.zeros((C, width), jnp.float32)
         dAbar = jnp.zeros((C, C), jnp.float32)
 
         def row_rev(i_rev, state):
             d_rhs_cur, dA = state
             i = active - 1 - i_rev
+            # Sensitivity at row i: accumulate incoming gradient before propagating
             dyi = lax.dynamic_slice(dy, (i, 0), (1, width))[0]
-            d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, dyi[None, :], (i, 0))
+            zi_prev = lax.dynamic_slice(d_rhs_cur, (i, 0), (1, width))[0]
+            zi = zi_prev + dyi  # total adjoint for row i
+            d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, zi[None, :], (i, 0))
 
             def upd_j(j, inner):
                 dA_cur, d_rhs_inner = inner
                 aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
                 decay = jnp.exp(g_cum[i] - g_cum[j])
-                yj = lax.dynamic_slice(d_rhs_cur, (j, 0), (1, width))[
-                    0
-                ]  # back‑sub structure uses already‑accumulated RHS
-                # dAbar[i,j] += <dyi, yj>
-                val = lax.dynamic_slice(dA_cur, (i, j), (1, 1))[0, 0] + jnp.sum(dyi * yj)
+                # dAbar[i,j] += <z_i, y_j>
+                yj = lax.dynamic_slice(Y_fwd, (j, 0), (1, width))[0]
+                val = lax.dynamic_slice(dA_cur, (i, j), (1, 1))[0, 0] + jnp.sum(zi * yj)
                 dA_cur = lax.dynamic_update_slice(dA_cur, jnp.asarray([[val]], jnp.float32), (i, j))
-                # d_rhs[j] += (aij * decay) * dyi
+                # back-prop to earlier rhs row j using accumulated adjoint z_i
                 d_rhs_inner = lax.dynamic_update_slice(
                     d_rhs_inner,
-                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, width))[0] + (aij * decay) * dyi)[None, :],
+                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, width))[0] + (aij * decay) * zi)[None, :],
                     (j, 0),
                 )
                 return (dA_cur, d_rhs_inner)
@@ -1842,36 +1854,26 @@ def _gdn_chunk_bwd_kernel_fused(
 
         return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
 
-    d_rhs_v, dAbar_v = bwd_sub(dyv, BV, True)  # seeds from dv_new_total
-    d_rhs_k, dAbar_k = bwd_sub(dyk, K, False)
+    # Use the FORWARD solutions computed above
+    d_rhs_v, dAbar_v = bwd_sub(dyv, yv)
+    d_rhs_k, dAbar_k = bwd_sub(dyk, yk)
 
     dAbar = dAbar_v + dAbar_k  # [C, C]
 
     # -------------------------------------------------------------------------
-    # Map dAbar → (dA0, d g_cum)   with  A = (A0 ⊙ decay), strictly lower
+    # Vectorized map: dAbar → (dA0, d g_cum).  A = (A0 ⊙ decay) on strictly-lower.
     # -------------------------------------------------------------------------
-    dA0 = jnp.zeros_like(A0)
-    dgc_from_A = jnp.zeros((C,), jnp.float32)
-
-    def tri_map(i, carry):
-        dA0_cur, dgc_cur = carry
-
-        def col(j, inner):
-            dA0_i, dgc_i = inner
-            aij0 = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-            decay = jnp.exp(g_cum[i] - g_cum[j])
-            dAij = lax.dynamic_slice(dAbar, (i, j), (1, 1))[0, 0]
-            # dA0 += dAbar * decay
-            val = lax.dynamic_slice(dA0_i, (i, j), (1, 1))[0, 0] + dAij * decay
-            dA0_i = lax.dynamic_update_slice(dA0_i, jnp.asarray([[val]], jnp.float32), (i, j))
-            # d g_cum: + on i, − on j
-            dgc_i = dgc_i.at[i].add(dAij * aij0 * decay)
-            dgc_i = dgc_i.at[j].add(-dAij * aij0 * decay)
-            return (dA0_i, dgc_i)
-
-        return lax.fori_loop(1, i + 1, col, (dA0_cur, dgc_cur))  # j ∈ [0, i-1]
-
-    dA0, dgc_from_A = lax.fori_loop(1, active, tri_map, (dA0, dgc_from_A))
+    # full decay matrix and strict-lower mask
+    decay_full = jnp.exp(g_cum[:, None] - g_cum[None, :])  # [C, C]
+    lower_mask = jnp.tril(jnp.ones((C, C), jnp.float32), k=-1)  # [C, C]
+    # active mask to clip rows/cols beyond 'active'
+    act_mask = (lax.iota(jnp.int32, C) < active).astype(jnp.float32)
+    tri_mask = lower_mask * act_mask[:, None] * act_mask[None, :]  # [C, C]
+    dAbar_full = dAbar * tri_mask  # keep strictly-lower, active only
+    dA0 = dAbar_full * decay_full  # [C, C], strictly-lower (no sign here; handled in Gram mapping)
+    # d g_cum:  + on row i, − on col j, scaled by A0[i,j] * decay[i,j]
+    contrib = dAbar_full * (A0 * decay_full)  # [C, C]
+    dgc_from_A = jnp.sum(contrib, axis=1) - jnp.sum(contrib, axis=0)  # [C]
 
     # -------------------------------------------------------------------------
     # RHS contributions
@@ -1883,28 +1885,29 @@ def _gdn_chunk_bwd_kernel_fused(
     dgc_from_k = eg * jnp.sum((b_c[:, None] * k_c) * d_rhs_k, axis=-1)  # [C]
 
     # -------------------------------------------------------------------------
-    # From A0:  A0[i,j] = -β_i <k_i, k_j>    (i > j)
+    # From A0:  A0[i,j] = sign * β_i <k_i, k_j> with sign = -1 (i > j)
+    # Use explicit i,j accumulation to mirror reference helper exactly
     # -------------------------------------------------------------------------
     dK_from_A0 = jnp.zeros_like(k_c)
     dB_from_A0 = jnp.zeros((C,), jnp.float32)
 
-    def gram_bwd(i, state):
+    def body_i(i, state):
         dK_acc, dB_acc = state
         ki = lax.dynamic_slice(k_c, (i, 0), (1, K))[0]
 
-        def body(j, carry):
-            dK_a, dB_a = carry
+        def body_j(j, inner):
+            dK_a, dB_a = inner
             kj = lax.dynamic_slice(k_c, (j, 0), (1, K))[0]
             dAij = lax.dynamic_slice(dA0, (i, j), (1, 1))[0, 0]
-            coeff = -(dAij * b_c[i])  # - dA0[i,j] * β_i
-            dK_a = dK_a.at[i, :].add(coeff * kj)  # ∂/∂k_i
-            dK_a = dK_a.at[j, :].add(coeff * ki)  # ∂/∂k_j
-            dB_a = dB_a + (-dAij) * jnp.sum(ki * kj)
+            coeff = -(dAij * b_c[i])  # sign = -1
+            dK_a = dK_a.at[i, :].add(coeff * kj)
+            dK_a = dK_a.at[j, :].add(coeff * ki)
+            dB_a = dB_a.at[i].add(-(dAij * jnp.sum(ki * kj)))
             return (dK_a, dB_a)
 
-        return lax.fori_loop(0, i, body, (dK_acc, dB_acc))
+        return lax.fori_loop(0, i, body_j, (dK_acc, dB_acc))
 
-    dK_from_A0, dB_from_A0 = lax.fori_loop(1, active, gram_bwd, (dK_from_A0, dB_from_A0))
+    dK_from_A0, dB_from_A0 = lax.fori_loop(1, active, body_i, (dK_from_A0, dB_from_A0))
 
     # -------------------------------------------------------------------------
     # Carry‑direct gradient wrt k:  dK_add (no triangular involvement)
@@ -1918,11 +1921,15 @@ def _gdn_chunk_bwd_kernel_fused(
     dQ_attn = dQ_attn * m[:, None]
     dQ_inter = dQ_inter * m[:, None]
 
-    dK_tile = (dK_attn + dK_rhs + dK_from_A0 + dK_add) * m[:, None]
+    dK_attn = dK_attn * m[:, None]
+    dK_rhs = dK_rhs * m[:, None]
+    dK_from_A0 = dK_from_A0 * m[:, None]
+    dK_add = dK_add * m[:, None]
+    dK_tile = dK_attn + dK_rhs + dK_from_A0 + dK_add
     dB_tile = (dB_from_v + dB_from_k + dB_from_A0) * m
 
-    # d g: combine all sources on g_cum then reverse‑cumsum to get d g
-    dgc_total = (dgc_attn + dgc_from_A + dgc_from_k) * m
+    # d g on g_cum (include inter), then reverse‑cumsum to get d g
+    dgc_total = (dgc_attn + dgc_from_A + dgc_from_k + dgc_inter) * m
 
     # carry contributions on g and S_prev:
     #   S_out = α_tail S_prev + Σ_i w_i k_i v_new_i^T
@@ -1975,6 +1982,13 @@ def _gdn_chunk_bwd_kernel_fused(
     dB_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dB_tile[None, None, :]
     dS_out_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)] = dS_out[None, :, :]
 
+    # component-wise debug writes
+    dK_attn_only_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_attn[None, None, :, :]
+    dK_rhs_only_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_rhs[None, None, :, :]
+    dK_A0_only_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_from_A0[None, None, :, :]
+    dK_add_only_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_add[None, None, :, :]
+    d_rhs_k_only_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = d_rhs_k[None, None, :, :]
+
 
 # ---------- fused backward (chunk) launcher ----------
 # NOTE: does the L2-norm backward *separately* for (dQ_attn, dQ_inter), then sums.
@@ -1994,16 +2008,32 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
     initial_state_was_none: bool,
     use_qk_l2norm_in_kernel: bool,
 ):
-    """Backward wrapper for the flash chunk kernel.
+    """Backward wrapper for the flash chunk kernel (fused), with heavy instrumentation.
 
-    Instrumented: emits per-chunk diffs for dQ_attn/inter (already good),
-    and for dK per-term (attn, RHS(yk), A0/Gram, and add/carry), using
-    both OUT-only seeds and TOTAL seeds, masked for ragged rows.
+    Debug prints (enable with `GDN_DEBUG_CHUNK_BWD=1`) include:
+      - dQ_attn / dQ_inter parity
+      - Per-term incremental diffs for dK: attn → +rhs(yk) → +A0(Gram) → +add(carry)
+      - dK_A0 checks: total vs ref, sign-flip residual, and "missing-col0" regression test
+      - dB TOTAL vs REF (v + rhs(yk) + A0)
+      - L2 bwd(K) closed-form vs VJP spot check
+
+    Notes:
+      * This function works in the "kernel space" (normalized q/k if requested) and
+        converts back to raw-space at the very end via the L2 backward mapping.
+      * The debug reference math re-solves the forward/back-sub per chunk to build
+        ground-truth comparisons; it is JIT-safe and masked for ragged rows.
     """
+    import os
+    import functools
+    import jax
+    from jax import lax
+    import jax.numpy as jnp
+    import jax.experimental.pallas as pl
 
-    _DBG = bool(int(os.environ.get("GDN_DEBUG_CHUNK_BWD", "0")))
+    # ---- settings / toggles -------------------------------------------------
+    _GDN_DBG_CHUNK_BWD = bool(int(os.environ.get("GDN_DEBUG_CHUNK_BWD", "0")))
 
-    # ---- unpack aux / static sizes from forward ----
+    # ---- unpack aux / static sizes from forward -----------------------------
     A0_buf = aux["A0_buf"]  # [NH, Nc, C, C]
     S_prev_buf = aux["S_prev_buf"]  # [NH, Nc, K, V_pad]
     T_pad = int(aux["T_pad"])
@@ -2030,6 +2060,15 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
         inv = lax.rsqrt(jnp.sum(X_raw * X_raw, axis=-1, keepdims=True) + eps)
         dot = jnp.sum(dY_norm * X_raw, axis=-1, keepdims=True)
         return scale * (inv * dY_norm - (inv**3) * X_raw * dot)
+
+    # Make a **shape-agnostic row mask** (fixes broadcast error in jnp.where)
+    def _mask_like(x, lengths_chunk):
+        # base mask: [NH, C]
+        base = lax.iota(jnp.int32, C)[None, :] < lengths_chunk[:, None]
+        # expand dims to match x.rank
+        while base.ndim < x.ndim:
+            base = base[..., None]
+        return base.astype(x.dtype)
 
     # ---------- normalize layout to NH-major (RAW views) ----------
     if head_first:
@@ -2173,11 +2212,11 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
 
         return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
 
-    def _gram_bwd_k(dA0, beta_c, k_chunk, active):
-        """Map dA0 (lower-tri) back to k via A0[i,j] = -β_i <k_i, k_j>"""
+    def _gram_bwd_k_db(dA0, beta_c, k_chunk, active, sign=-1.0):
+        """Map dA0 (lower-tri) → (dK, dB) for A0[i,j] = sign * β_i <k_i, k_j>, i>j."""
         NH_, C_, K_ = k_chunk.shape
         dK = jnp.zeros((NH_, C_, K_), jnp.float32)
-        dB = jnp.zeros((NH_, C_), jnp.float32)  # not printed here
+        dB = jnp.zeros((NH_, C_), jnp.float32)
 
         def row_i(i, state):
             dK_acc, dB_acc = state
@@ -2186,18 +2225,19 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
             def col_j(j, inner):
                 dK_a, dB_a = inner
                 kj = k_chunk[:, j, :]
-                coeff = -(lax.dynamic_slice(dA0, (0, i, j), (NH_, 1, 1))[:, 0, 0] * beta_c[:, i])  # [NH]
+                dAij = lax.dynamic_slice(dA0, (0, i, j), (NH_, 1, 1))[:, 0, 0]  # [NH]
+                coeff = -(dAij * beta_c[:, i]) * (1.0 if sign < 0 else -1.0)  # handle sign flip compactly
                 dK_a = dK_a.at[:, i, :].add(coeff[:, None] * kj)
                 dK_a = dK_a.at[:, j, :].add(coeff[:, None] * ki)
-                dB_a = dB_a.at[:, i].add(
-                    -(lax.dynamic_slice(dA0, (0, i, j), (NH_, 1, 1))[:, 0, 0]) * jnp.sum(ki * kj, axis=-1)
-                )
+                # dB[i] += -dAij * <ki, kj> * (sign)  (because ∂A0/∂β_i = sign * <ki,kj>)
+                dB_a = dB_a.at[:, i].add((-dAij * jnp.sum(ki * kj, axis=-1)) * (1.0 if sign < 0 else -1.0))
                 return (dK_a, dB_a)
 
             return lax.fori_loop(0, i, col_j, (dK_acc, dB_acc))
 
-        return lax.fori_loop(1, active, row_i, (dK, dB))[0]  # return dK only
+        return lax.fori_loop(1, active, row_i, (dK, dB))
 
+    # === kernel to call per (chunk × V-tile) ===
     kernel = functools.partial(_gdn_chunk_bwd_kernel_fused, C=int(C), K=int(K), BV=int(BV))
 
     # ---------- reverse over chunks ----------
@@ -2206,7 +2246,7 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
         ci = jnp.int32(Nc - 1 - i)
         c0 = ci * C
         lengths_chunk = jnp.clip(lengths_flat - jnp.int32(c0), 0, jnp.int32(C))  # [NH]
-        active = jnp.min(lengths_chunk)  # all batches in test are full; we still mask below
+        active = jnp.min(lengths_chunk)
 
         # slice per-chunk tensors (outside the kernel; static sizes inside)
         q_chunk_fwd = lax.dynamic_slice(q_flat_fwd, (0, c0, 0), (NH, C, K))
@@ -2224,17 +2264,48 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
         dV_c = jnp.zeros((NH, C, V_pad), jnp.float32)
         dG_c = jnp.zeros((NH, C), jnp.float32)
         dB_c = jnp.zeros((NH, C), jnp.float32)
+        # component accumulators for debugging
+        dK_attn_comp = jnp.zeros((NH, C, K), jnp.float32)
+        dK_rhs_comp = jnp.zeros((NH, C, K), jnp.float32)
+        dK_A0_comp = jnp.zeros((NH, C, K), jnp.float32)
+        dK_add_comp = jnp.zeros((NH, C, K), jnp.float32)
+        d_rhs_k_comp = jnp.zeros((NH, C, K), jnp.float32)
 
         # ---- per-VT loop (kernel call) ----
         def one_vt(vt, acc):
-            dQ_acc_t, dK_acc_t, dV_acc_t, dG_acc_t, dB_acc_t, dS_in_prev = acc
+            (
+                dQ_acc_t,
+                dK_acc_t,
+                dV_acc_t,
+                dG_acc_t,
+                dB_acc_t,
+                dS_in_prev,
+                dK_attn_acc,
+                dK_rhs_acc,
+                dK_A0_acc,
+                dK_add_acc,
+                d_rhs_k_acc,
+            ) = acc
 
             v_tile = lax.dynamic_slice(v_chunk, (0, 0, vt * BV), (NH, C, BV))
             dY_tile = lax.dynamic_slice(dY_chunk, (0, 0, vt * BV), (NH, C, BV))
             S_prev_t = lax.dynamic_slice(S_prev_chunk, (0, 0, vt * BV), (NH, K, BV))
             dS_in_t = lax.dynamic_slice(dS_in, (0, 0, vt * BV), (NH, K, BV))
 
-            dQ_attn_t, dQ_inter_t, dK_t, dV_t, dG_t, dB_t, dS_out_t = pl.pallas_call(
+            (
+                dQ_attn_t,
+                dQ_inter_t,
+                dK_t,
+                dV_t,
+                dG_t,
+                dB_t,
+                dS_out_t,
+                dK_attn_only_t,
+                dK_rhs_only_t,
+                dK_A0_only_t,
+                dK_add_only_t,
+                d_rhs_k_only_t,
+            ) = pl.pallas_call(
                 kernel,
                 out_shape=(
                     jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dQ_attn (normalized space)
@@ -2244,6 +2315,11 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
                     jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),  # dG
                     jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),  # dB
                     jax.ShapeDtypeStruct((NH, K, BV), jnp.float32),  # dS_out
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dK_attn_only
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dK_rhs_only
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dK_A0_only
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # dK_add_only
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),  # d_rhs_k_only
                 ),
                 grid=(NH,),
                 in_specs=(
@@ -2266,6 +2342,11 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
                     pl.BlockSpec((1, 1, C), lambda nh: (nh, 0, 0)),
                     pl.BlockSpec((1, 1, C), lambda nh: (nh, 0, 0)),
                     pl.BlockSpec((1, K, BV), lambda nh: (nh, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
                 ),
                 interpret=_should_interpret_pallas(),
             )(
@@ -2285,6 +2366,12 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
             dQ_acc_t = dQ_acc_t + dQ_attn_t[:, 0, :, :]
             # K/V/G/B accumulate as usual
             dK_acc_t = dK_acc_t + dK_t[:, 0, :, :]
+            dK_attn_acc = dK_attn_acc + dK_attn_only_t[:, 0, :, :]
+            dK_rhs_acc = dK_rhs_acc + dK_rhs_only_t[:, 0, :, :]
+            dK_A0_acc = dK_A0_acc + dK_A0_only_t[:, 0, :, :]
+            dK_add_acc = dK_add_acc + dK_add_only_t[:, 0, :, :]
+            # accumulate d_rhs_k across V-tiles
+            d_rhs_k_acc = d_rhs_k_acc + d_rhs_k_only_t[:, 0, :, :]
             # tile-scatter for V
             start = vt * jnp.int32(BV)
             dv_old = lax.dynamic_slice(dV_acc_t, (0, 0, start), (NH, C, BV))
@@ -2295,10 +2382,49 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
             dB_acc_t = dB_acc_t + dB_t[:, 0, :]
             # pass dS_out along V-tiles
             dS_in_prev = lax.dynamic_update_slice(dS_in_prev, dS_out_t, (0, 0, start))
-            return (dQ_acc_t, dK_acc_t, dV_acc_t, dG_acc_t, dB_acc_t, dS_in_prev)
+            return (
+                dQ_acc_t,
+                dK_acc_t,
+                dV_acc_t,
+                dG_acc_t,
+                dB_acc_t,
+                dS_in_prev,
+                dK_attn_acc,
+                dK_rhs_acc,
+                dK_A0_acc,
+                dK_add_acc,
+                d_rhs_k_acc,
+            )
 
-        dQ_c_norm, dK_c_norm, dV_c, dG_c, dB_c, dS_out = lax.fori_loop(
-            0, n_vtiles, one_vt, (dQ_c_norm, dK_c_norm, dV_c, dG_c, dB_c, jnp.zeros_like(dS_in))
+        (
+            dQ_c_norm,
+            dK_c_norm,
+            dV_c,
+            dG_c,
+            dB_c,
+            dS_out,
+            dK_attn_comp,
+            dK_rhs_comp,
+            dK_A0_comp,
+            dK_add_comp,
+            d_rhs_k_comp,
+        ) = lax.fori_loop(
+            0,
+            n_vtiles,
+            one_vt,
+            (
+                dQ_c_norm,
+                dK_c_norm,
+                dV_c,
+                dG_c,
+                dB_c,
+                jnp.zeros_like(dS_in),
+                dK_attn_comp,
+                dK_rhs_comp,
+                dK_A0_comp,
+                dK_add_comp,
+                d_rhs_k_comp,
+            ),
         )
 
         # === add dQ_inter once (full-V) ===
@@ -2308,102 +2434,81 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
         dQ_c_norm = dQ_c_norm + dQ_inter_chunk
 
         # ---------- DEBUG: dQ paths (should be ~0 diffs already) ----------
-        if _DBG:
+        if _GDN_DBG_CHUNK_BWD:
             # inter
             diff_inter = dQ_inter_chunk - ((dY_chunk @ jnp.transpose(S_prev_chunk, (0, 2, 1))) * eg_full[:, :, None])
-            max_abs = jnp.max(jnp.abs(diff_inter))
-            nh0_max = jnp.max(jnp.abs(diff_inter[0]))
             jax.debug.print(
                 "[GDN dbg] chunk={ci} NH={NH} C={C} K={K}  dQ_inter  max|Δ|={ma:.3e}  NH0 max|Δ|={m0:.3e}",
                 ci=ci,
                 NH=jnp.array(NH),
                 C=jnp.array(C),
                 K=jnp.array(K),
-                ma=max_abs,
-                m0=nh0_max,
+                ma=jnp.max(jnp.abs(diff_inter)),
+                m0=jnp.max(jnp.abs(diff_inter[0])),
             )
             # attn (recompute ref)
             g_cum = jnp.cumsum(g_chunk, axis=1)
-            eg = jnp.exp(g_cum)
             yv_ref = _fs_yv_ref(A0_chunk, g_cum, b_chunk, v_chunk, active)
             yk_ref = _fs_yk_ref(A0_chunk, g_cum, b_chunk, k_chunk_fwd, active)
             v_new_ref = yv_ref - jnp.einsum("nck,nkv->ncv", yk_ref, S_prev_chunk)
-            # qk_raw = jnp.einsum("nck,ndk->ncd", q_chunk_fwd, k_chunk_fwd)
             decay = jnp.exp(g_cum[:, :, None] - g_cum[:, None, :])
             tril = jnp.tril(jnp.ones((C, C), jnp.float32))[None, :, :]
             M_full = decay * tril
             dAttn_ref = jnp.einsum("ncv,nwv->ncw", dY_chunk, v_new_ref)
             dQ_attn_ref = jnp.einsum("ncw,nwk->nck", M_full * dAttn_ref, k_chunk_fwd)
-            diff_attn = (jnp.where(jnp.arange(C)[None, :] < lengths_chunk[:, None], 1.0, 0.0)[:, :, None]) * (
-                dQ_attn_only - dQ_attn_ref
-            )
+            # mask robustly
+            mask_q = _mask_like(dQ_attn_ref, lengths_chunk)
             jax.debug.print(
                 "[GDN dbg] chunk={ci} NH={NH} C={C} K={K}  dQ_attn  max|Δ|={m:.3e}",
                 ci=ci,
                 NH=jnp.array(NH),
                 C=jnp.array(C),
                 K=jnp.array(K),
-                m=jnp.max(jnp.abs(diff_attn)),
+                m=jnp.max(jnp.abs((dQ_attn_only - dQ_attn_ref) * mask_q)),
             )
 
-        # ---------- DEBUG: K per-term reference and diffs ----------
-        if _DBG:
-            # Shapes
-            # q_chunk_fwd:  [NH, C, K]
-            # k_chunk_fwd:  [NH, C, K]
-            # v_chunk:      [NH, C, V_pad]
-            # g_chunk:      [NH, C]
-            # b_chunk:      [NH, C]
-            # A0_chunk:     [NH, C, C]
-            # S_prev_chunk: [NH, K, V_pad]
-            # dY_chunk:     [NH, C, V_pad]
-            # dS_in:        [NH, K, V_pad]  (incoming carry to this chunk)
+            # ---------- DEBUG: K per-term reference and diffs ----------
             g_cum = jnp.cumsum(g_chunk, axis=1)  # [NH, C]
             eg = jnp.exp(g_cum)  # [NH, C]
-            tril = jnp.tril(jnp.ones((C, C), jnp.float32))[None, :, :]  # [1, C, C]
+            tril = jnp.tril(jnp.ones((C, C), jnp.float32))[None]
             decay = jnp.exp(g_cum[:, :, None] - g_cum[:, None, :])  # [NH, C, C]
-            M_full = decay * tril  # [NH, C, C]
+            M_full = decay * tril
 
-            # Re-solve the forward substitution (reference)
             yv_ref = _fs_yv_ref(A0_chunk, g_cum, b_chunk, v_chunk, active)  # [NH, C, V_pad]
             yk_ref = _fs_yk_ref(A0_chunk, g_cum, b_chunk, k_chunk_fwd, active)  # [NH, C, K]
-            v_new_ref = yv_ref - jnp.einsum("nck,nkv->ncv", yk_ref, S_prev_chunk)  # [NH, C, V_pad]
+            v_new_ref = yv_ref - jnp.einsum("nck,nkv->ncv", yk_ref, S_prev_chunk)
 
             # Seeds from the output path: dv_new_out = attn^T @ dY
-            # attn(i,j) = M(i,j) * <q_i, k_j>
             qk = jnp.einsum("nck,njk->ncj", q_chunk_fwd, k_chunk_fwd)  # [NH, C, C] (i,j)
-            attn = M_full * qk  # [NH, C, C] (i,j)
-            dv_new_out = jnp.einsum("nij,niv->njv", attn, dY_chunk)  # [NH, C, V_pad] = attn^T @ dY
-
-            # Carry path: dv_new_carry = (k @ dS_in) * w
-            # NOTE: JIT-safe broadcasting: [:, None] to match [NH, C]
+            attn = M_full * qk
+            dv_new_out = jnp.einsum("nij,niv->njv", attn, dY_chunk)  # [NH, C, V_pad]
+            # Carry path
             w = jnp.exp(g_cum[:, -1][:, None] - g_cum)  # [NH, C]
             kv_dS = jnp.einsum("nck,nkv->ncv", k_chunk_fwd, dS_in)  # [NH, C, V_pad]
-            dv_new_tot = dv_new_out + kv_dS * w[:, :, None]  # [NH, C, V_pad]
+            dv_new_tot = dv_new_out + kv_dS * w[:, :, None]
 
-            # Backward-sub seeds for the triangular solves
+            # Backward-sub seeds
             S_prev_T = jnp.transpose(S_prev_chunk, (0, 2, 1))  # [NH, V_pad, K]
             dyk_out = -jnp.einsum("ncv,nvk->nck", dv_new_out, S_prev_T)  # [NH, C, K]
-            dyv_out = dv_new_out  # [NH, C, V_pad]
+            dyv_out = dv_new_out
             dyk_tot = -jnp.einsum("ncv,nvk->nck", dv_new_tot, S_prev_T)  # [NH, C, K]
-            dyv_tot = dv_new_tot  # [NH, C, V_pad]
+            dyv_tot = dv_new_tot
 
-            # Backward-substitution (reference) to RHS and dAbar
+            # Backward-substitution (reference)
             d_rhs_v_out, dAbar_v_out = _bwd_sub_ref(dyv_out, A0_chunk, g_cum, yv_ref, active)
             d_rhs_k_out, dAbar_k_out = _bwd_sub_ref(dyk_out, A0_chunk, g_cum, yk_ref, active)
             d_rhs_v_tot, dAbar_v_tot = _bwd_sub_ref(dyv_tot, A0_chunk, g_cum, yv_ref, active)
             d_rhs_k_tot, dAbar_k_tot = _bwd_sub_ref(dyk_tot, A0_chunk, g_cum, yk_ref, active)
 
             # Map RHS(yk) → dK_rhs
-            scale = eg[:, :, None] * b_chunk[:, :, None]  # [NH, C, 1]
-            # dK_rhs_out = scale * d_rhs_k_out  # [NH, C, K]
-            dK_rhs_tot = scale * d_rhs_k_tot  # [NH, C, K]
+            scale_rhs = eg[:, :, None] * b_chunk[:, :, None]  # [NH, C, 1]
+            dK_rhs_tot = scale_rhs * d_rhs_k_tot
 
             # Map dAbar → dA0 (via decay) → dK_A0 (Gram route)
-            # dA0_out = (dAbar_v_out + dAbar_k_out) * decay  # [NH, C, C]
-            dA0_tot = (dAbar_v_tot + dAbar_k_tot) * decay  # [NH, C, C]
-            # dK_A0_out = _gram_bwd_k(dA0_out, b_chunk, k_chunk_fwd, active)  # [NH, C, K]
-            dK_A0_tot = _gram_bwd_k(dA0_tot, b_chunk, k_chunk_fwd, active)  # [NH, C, K]
+            lower = jnp.tril(jnp.ones((C, C), jnp.float32), k=-1)[None]
+            dAbar_tot = dAbar_v_tot + dAbar_k_tot
+            dA0_tot = (dAbar_tot * decay) * lower
+            dK_A0_tot, dB_A0_tot = _gram_bwd_k_db(dA0_tot, b_chunk, k_chunk_fwd, active, sign=-1.0)
 
             # dK_add (carry S_out term)
             dK_add_ref = jnp.einsum("nkv,ncv->nkc", dS_in, v_new_ref).transpose(0, 2, 1) * w[:, :, None]
@@ -2412,32 +2517,208 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
             dAttn_ref = jnp.einsum("ncv,nwv->ncw", dY_chunk, v_new_ref)  # [NH, C, C]
             dK_attn_ref = jnp.einsum("nij,nik->njk", M_full * dAttn_ref, q_chunk_fwd)  # [NH, C, K]
 
-            # Mask ragged rows
-            row_ids = lax.iota(jnp.int32, C)[None, :]  # [1, C]
-            mask_rows = (row_ids < lengths_chunk[:, None])[:, :, None]  # [NH, C, 1]
-            m3 = lambda x: jnp.where(mask_rows, x, 0.0)
+            # Compose references with robust row masking
+            mK = _mask_like(dK_attn_ref, lengths_chunk)  # [NH,C,1] broadcasted to [NH,C,K]
+            dK_ref_tot = (dK_attn_ref + dK_rhs_tot + dK_A0_tot + dK_add_ref) * mK
+            dK_cur_m = dK_c_norm * mK
 
-            # Compose references
-            dK_ref_tot = m3(dK_attn_ref + dK_rhs_tot + dK_A0_tot + dK_add_ref)
-            dK_cur_m = m3(dK_c_norm)
+            # Direct component parity (from kernel component outputs)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_attn(comp) vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((dK_attn_comp - dK_attn_ref) * mK)),
+            )
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_rhs(comp) vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((dK_rhs_comp - dK_rhs_tot) * mK)),
+            )
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_A0(comp) vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((dK_A0_comp - dK_A0_tot) * mK)),
+            )
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_add(comp) vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((dK_add_comp - dK_add_ref) * mK)),
+            )
+
+            # Drill into d_rhs_k via inversion of scaling
+            scale_rhs_ref = eg[:, :, None] * b_chunk[:, :, None]
+            eps = jnp.asarray(1e-12, jnp.float32)
+            valid = (mK > 0) & (jnp.abs(scale_rhs_ref) > eps)
+            d_rhs_k_est = jnp.where(valid, dK_rhs_comp / (scale_rhs_ref + eps), 0.0)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} d_rhs_k(comp) vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((d_rhs_k_est - d_rhs_k_tot) * mK)),
+            )
+            # Direct kernel d_rhs_k vs REF
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} d_rhs_k(direct) vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((d_rhs_k_comp - d_rhs_k_tot) * mK)),
+            )
+
+            # ----- dG parity (total) -----
+            # attn part
+            W = (qk * dAttn_ref) * decay * tril  # [NH,C,C]
+            dgc_attn_ref = jnp.sum(W, axis=2) - jnp.sum(W, axis=1)  # [NH,C]
+            # from A
+            contrib = dAbar_tot * (A0_chunk * decay)  # [NH,C,C]
+            dgc_from_A_ref = jnp.sum(contrib, axis=2) - jnp.sum(contrib, axis=1)
+            # from k
+            dgc_from_k_ref = eg * jnp.sum((b_chunk[:, :, None] * k_chunk_fwd) * d_rhs_k_tot, axis=-1)
+            # inter term:  <dY_i, S_prev^T q_i> * e^{g_cum[i]}
+            inter_base_ref = jnp.einsum("nck,nkv->ncv", q_chunk_fwd, S_prev_chunk)  # [NH,C,V_pad]
+            dgc_inter_ref = eg * jnp.sum(inter_base_ref * dY_chunk, axis=-1)  # [NH,C]
+            # carry terms
+            s_i = jnp.sum(kv_dS * v_new_ref, axis=-1)
+            dgt_from_w_ref = jnp.sum(w * s_i, axis=1)
+            dgc_from_w_ref = -w * s_i
+            dgt_from_alpha_ref = jnp.exp(g_cum[:, -1]) * jnp.sum(S_prev_chunk * dS_in, axis=(1, 2))
+            base = dgc_from_w_ref
+            idx_last = jnp.minimum(lengths_chunk, jnp.int32(C)) - jnp.int32(1)
+
+            def _add_tail_row(nh_i, base_row):
+                idx = idx_last[nh_i]
+                upd = base_row.at[idx].add(dgt_from_alpha_ref[nh_i] + dgt_from_w_ref[nh_i])
+                return upd
+
+            dgc_carry_ref = jax.vmap(_add_tail_row, in_axes=(0, 0))(jnp.arange(NH), base)
+            dG_ref = (dgc_attn_ref + dgc_from_A_ref + dgc_from_k_ref + dgc_inter_ref) + dgc_carry_ref
+            mG = _mask_like(dG_ref, lengths_chunk)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dG TOTAL vs REF  max|Δ|={m:.3e}", ci=ci, m=jnp.max(jnp.abs((dG_c - dG_ref) * mG))
+            )
+            # (debug only) report parity; do not override outputs here
 
             # Incremental diffs (TOTAL seeds)
             jax.debug.print(
                 "[GDN dbg] chunk={ci} dK incr diffs (TOTAL): "
                 "after attn={d1:.3e}  after +rhs={d2:.3e}  after +A0={d3:.3e}  after +add={d4:.3e}",
                 ci=ci,
-                d1=jnp.max(jnp.abs(dK_cur_m - m3(dK_attn_ref))),
-                d2=jnp.max(jnp.abs(dK_cur_m - m3(dK_attn_ref + dK_rhs_tot))),
-                d3=jnp.max(jnp.abs(dK_cur_m - m3(dK_attn_ref + dK_rhs_tot + dK_A0_tot))),
+                d1=jnp.max(jnp.abs(dK_cur_m - (dK_attn_ref * mK))),
+                d2=jnp.max(jnp.abs(dK_cur_m - ((dK_attn_ref + dK_rhs_tot) * mK))),
+                d3=jnp.max(jnp.abs(dK_cur_m - ((dK_attn_ref + dK_rhs_tot + dK_A0_tot) * mK))),
                 d4=jnp.max(jnp.abs(dK_cur_m - dK_ref_tot)),
             )
-
-            # Final per-term residual checks (TOTAL seeds)
             jax.debug.print(
                 "[GDN dbg] chunk={ci} dK TOTAL vs REF  max|Δ|={mt:.3e}",
                 ci=ci,
                 mt=jnp.max(jnp.abs(dK_cur_m - dK_ref_tot)),
             )
+
+            # Pinpoint the worst index and print scalar breakdown
+            diff = jnp.abs(dK_cur_m - dK_ref_tot)
+            flat_idx = jnp.argmax(diff.reshape(-1))
+            nh_idx = flat_idx // (C * K)
+            rem = flat_idx % (C * K)
+            i_idx = rem // K
+            k_idx = rem % K
+
+            def _at(x):
+                return x[nh_idx, i_idx, k_idx]
+
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} worst @ (nh={nh}, i={i}, k={k}) | kernel={kc:.6e} ref={rc:.6e} | attn={a:.6e} rhs={r:.6e} A0={aa:.6e} add={ad:.6e}",
+                ci=ci,
+                nh=nh_idx,
+                i=i_idx,
+                k=k_idx,
+                kc=_at(dK_cur_m),
+                rc=_at(dK_ref_tot),
+                a=_at(dK_attn_ref),
+                r=_at(dK_rhs_tot),
+                aa=_at(dK_A0_tot),
+                ad=_at(dK_add_ref),
+            )
+            # (ratio check removed to avoid ordering issues)
+
+            # Isolate A0 contribution produced by kernel (estimate)
+            dK_A0_est = dK_c_norm - (dK_attn_ref + dK_rhs_tot + dK_add_ref) * mK
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_A0  max|Δ|={m:.3e}", ci=ci, m=jnp.max(jnp.abs(dK_A0_est - (dK_A0_tot * mK)))
+            )
+
+            # Sign-flip residual check (compare to A0 with +sign)
+            dK_A0_pos, _ = _gram_bwd_k_db(dA0_tot, b_chunk, k_chunk_fwd, active, sign=+1.0)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_A0 sign-flip residual  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs(dK_A0_est - (dK_A0_pos * mK))),
+            )
+
+            # "missing col0" regression test: zero the j=0 column in dA0 and compare
+            j_idx = jnp.arange(C)[None, None, :]  # [1,1,C]
+            mask_wrong = lower * (j_idx >= 1).astype(jnp.float32)  # drop col 0
+            dA0_wrong = dAbar_tot * decay * mask_wrong
+            dK_A0_wrong, _ = _gram_bwd_k_db(dA0_wrong, b_chunk, k_chunk_fwd, active, sign=-1.0)
+            dK_A0_resid = dK_A0_wrong - dK_A0_tot
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_A0 missing-col0 check  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs(dK_A0_resid * mK)),
+            )
+
+            # Additional isolation: rhs-only diff
+            dK_rhs_est = dK_c_norm - ((dK_attn_ref + dK_A0_tot + dK_add_ref) * mK)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_rhs  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs(dK_rhs_est - (dK_rhs_tot * mK))),
+            )
+            dK_add_est = dK_c_norm - ((dK_attn_ref + dK_rhs_tot + dK_A0_tot) * mK)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_add  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs(dK_add_est - (dK_add_ref * mK))),
+            )
+            dK_attn_est = dK_c_norm - ((dK_rhs_tot + dK_A0_tot + dK_add_ref) * mK)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dK_attn  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs(dK_attn_est - (dK_attn_ref * mK))),
+            )
+
+            # dAbar parity (trivial since both paths are re-computed here)
+            Abar_tot_ref = dAbar_v_tot + dAbar_k_tot
+            Abar_tot_cur = dAbar_tot
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dAbar  max|Δ|={m:.3e}", ci=ci, m=jnp.max(jnp.abs(Abar_tot_cur - Abar_tot_ref))
+            )
+
+            # ---------------- dB TOTAL vs REF (v + rhs(yk) + A0) ----------------
+            # v-path:
+            dB_from_v_ref = jnp.sum(v_chunk * d_rhs_v_tot, axis=-1)  # [NH,C]
+            # rhs(yk)-path:
+            dB_from_k_ref = jnp.sum((eg[:, :, None] * k_chunk_fwd) * d_rhs_k_tot, axis=-1)  # [NH,C]
+            # A0(Gram)-path:
+            _, dB_A0_ref = _gram_bwd_k_db(dA0_tot, b_chunk, k_chunk_fwd, active, sign=-1.0)  # [NH,C]
+            dB_ref_total = dB_from_v_ref + dB_from_k_ref + dB_A0_ref
+            mB = _mask_like(dB_ref_total, lengths_chunk)  # [NH,C] shaped
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dB TOTAL vs REF  max|Δ|={m:.3e}",
+                ci=ci,
+                m=jnp.max(jnp.abs((dB_c - dB_ref_total) * mB)),
+            )
+
+            # Break down dB components
+            dB_A0_est = dB_c - (dB_from_v_ref + dB_from_k_ref)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dB_A0  max|Δ|={m:.3e}", ci=ci, m=jnp.max(jnp.abs(dB_A0_est - dB_A0_ref))
+            )
+            dB_v_est = dB_c - (dB_from_k_ref + dB_A0_ref)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dB_v  max|Δ|={m:.3e}", ci=ci, m=jnp.max(jnp.abs(dB_v_est - dB_from_v_ref))
+            )
+            dB_k_est = dB_c - (dB_from_v_ref + dB_A0_ref)
+            jax.debug.print(
+                "[GDN dbg] chunk={ci} dB_rhs(yk)  max|Δ|={m:.3e}", ci=ci, m=jnp.max(jnp.abs(dB_k_est - dB_from_k_ref))
+            )
+
+            # (debug only) report parity; do not override outputs here
 
         # Scatter per-chunk grads into carried accumulators (kernel space)
         old = lax.dynamic_slice(dQ_acc, (0, c0, 0), (NH, C, K))
@@ -2470,7 +2751,7 @@ def _chunk_gated_delta_rule_flash_bwd_fused(
         dK_flat_raw = dK_flat_norm
 
     # tiny self-check of the per-row VJP mapping for K (optional)
-    if _DBG:
+    if _GDN_DBG_CHUNK_BWD:
 
         def norm_k_row(x):  # y = x / ||x||
             inv = lax.rsqrt(jnp.sum(x * x) + jnp.asarray(1e-6, x.dtype))

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -1290,74 +1290,18 @@ def _chunk_gated_delta_rule_reference(
     return (out_final, S) if output_final_state else (out_final, None)
 
 
-def _build_T_from_kbeta(
-    k_c: jnp.ndarray,  # (C, K)  L2-normalized K for this chunk (fp32)
-    b_c: jnp.ndarray,  # (C,)    beta for this chunk (fp32)
-    g_cum: jnp.ndarray,  # (C,)    cumulative g within chunk (fp32)
-    *,
-    K: int,
-    BK: int,
-) -> jnp.ndarray:
-    """Build T = (I - A)^(-1) for a chunk with only static-shape slices (Pallas-safe)."""
-    C = k_c.shape[0]
-
-    # --- A[i,j] = -exp(g_i - g_j) * <kβ_i, k_j> for j < i; else 0 ---
-    def dot_full(i, j):
-        # <kβ_i, k_j> = b_i * <k_i, k_j>, reduced over K in BK tiles
-        def body(kb2, s):
-            kk = kb2 * BK
-            ki = lax.dynamic_slice(k_c, (i, kk), (1, BK))[0]  # (BK,)
-            kj = lax.dynamic_slice(k_c, (j, kk), (1, BK))[0]  # (BK,)
-            return s + jnp.sum((b_c[i] * ki) * kj, dtype=jnp.float32)
-
-        n_kb2 = (K + BK - 1) // BK
-        return lax.fori_loop(0, n_kb2, body, jnp.array(0.0, jnp.float32))
-
-    # Fill A one row at a time, writing only j<i
-    A = jnp.zeros((C, C), dtype=jnp.float32)
-
-    def fill_A_row(i, A_cur):
-        row = jnp.zeros((C,), dtype=jnp.float32)
-
-        def inner(j, r):
-            coeff = -jnp.exp(g_cum[i] - g_cum[j]) * dot_full(i, j)
-            return r.at[j].set(coeff)
-
-        row = lax.fori_loop(0, i, inner, row)  # j = 0..i-1
-        return lax.dynamic_update_slice(A_cur, row[None, :], (i, 0))
-
-    A = lax.fori_loop(1, C, fill_A_row, A)
-
-    # --- Forward substitution to get T - I, row by row ---
-    # Invariant: after processing i-1, TL[:i,:] holds (T - I) rows 0..i-1.
-    TL = A
-
-    def fwd_sub_row(i, TL_cur):
-        row = lax.dynamic_slice(TL_cur, (i, 0), (1, C))[0]  # A[i,:]
-        # zero out entries >= i so 'row @ TL_cur' only uses j < i automatically
-        ar = lax.broadcasted_iota(jnp.int32, (C,), 0)
-        m1 = (ar < jnp.int32(i)).astype(jnp.float32)
-        row_pref = row * m1  # (C,)
-        incr = row_pref @ TL_cur  # (C,) == Σ_{j<i} row[j] * TL[j,:]
-        row_new = row + incr * m1  # keep strictly-lower structure
-        return lax.dynamic_update_slice(TL_cur, row_new[None, :], (i, 0))
-
-    TL = lax.fori_loop(1, C, fwd_sub_row, TL)
-    T = TL + jnp.eye(C, dtype=jnp.float32)
-    return T
-
-
 def _gdn_chunk_fwd_kernel_fused(
     q_ref,  # [NH, T_pad, K]
     k_ref,  # [NH, T_pad, K]
     v_ref,  # [NH, T_pad, V_pad]
     g_ref,  # [NH, T_pad]
     beta_ref,  # [NH, T_pad]
-    s_prev_ref,  # [NH, K, V_pad]
+    s_prev_ref,  # [NH, K, BV]
     ci_ref,  # [1]  int32 (chunk index)
     lengths_ref,  # [NH] int32 (per sequence length)
     out_tile_ref,  # [NH, 1, C, BV]
     s_tile_ref,  # [NH, 1, K, BV]
+    a0_tile_ref,  # [NH, 1, C, C]
     *,
     T_pad: int,
     K: int,
@@ -1368,63 +1312,61 @@ def _gdn_chunk_fwd_kernel_fused(
 ):
     nh = pl.program_id(0)
     vt = pl.program_id(1)
-    ci = ci_ref[dslice(0, 1)][0].astype(jnp.int32)
 
-    # --- chunk start, active length for this sequence ---
+    # --- chunk index / active rows
+    ci = ci_ref[dslice(0, 1)][0].astype(jnp.int32)
     c0 = ci * jnp.int32(chunk_len)
     Lnh = lengths_ref[dslice(nh, 1)][0].astype(jnp.int32)
-    rem = Lnh - c0  # remaining tokens from this chunk start
-    active = jnp.clip(rem, jnp.int32(0), jnp.int32(chunk_len))  # in [0, C]
-
-    # Dynamic row mask for positions < active (float32 for mul)
-    ar = lax.iota(jnp.int32, chunk_len)  # [0..C-1]
+    active = jnp.clip(Lnh - c0, 0, jnp.int32(chunk_len))
+    ar = lax.iota(jnp.int32, chunk_len)
     m = (ar < active).astype(jnp.float32)  # (C,)
 
-    # --- Read chunk slices (C = chunk_len) ---
-    q_c = q_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C, K)
-    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)  # (C, K)
+    # --- read chunk views
+    q_c = q_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)
+    k_c = k_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(0, K)][0].astype(jnp.float32)
     v_c = v_ref[dslice(nh, 1), dslice(c0, chunk_len), dslice(v0 := vt * jnp.int32(BV), BV)][0].astype(jnp.float32)
-    g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)  # (C,)
-    b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)  # (C,)
-    S_prev_v = s_prev_ref[dslice(nh, 1), dslice(0, K), dslice(v0, BV)][0].astype(jnp.float32)  # (K, BV)
+    g_c = g_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
+    b_c = beta_ref[dslice(nh, 1), dslice(c0, chunk_len)][0].astype(jnp.float32)
+    S_prev_v = s_prev_ref[dslice(nh, 1), dslice(0, K), dslice(v0, BV)][0].astype(jnp.float32)
 
-    # Apply row masks to q,k,v,β  (positions ≥ active become zero)
+    # mask inactive rows
     q_c = q_c * m[:, None]
     k_c = k_c * m[:, None]
     v_c = v_c * m[:, None]
     b_c = b_c * m
 
-    # --- g_cum and tail selection from last valid index (varlen-safe) ---
-    g_cum = jnp.cumsum(g_c, axis=0)  # (C,)
+    # cumulative g, tail, exp(g)
+    g_cum = jnp.cumsum(g_c, axis=0)
+    eg = jnp.exp(g_cum)
+    g_tail = lax.cond(
+        active > 0,
+        lambda _: lax.dynamic_slice_in_dim(g_cum, active - 1, 1, axis=0)[0],
+        lambda _: jnp.array(0.0, jnp.float32),
+        operand=None,
+    )
+    alpha_tail = jnp.exp(g_tail)
 
-    def _pick_tail(_):
-        return lax.dynamic_slice_in_dim(g_cum, active - 1, 1, axis=0)[0]
-
-    g_tail = lax.cond(active > 0, _pick_tail, lambda _: jnp.array(0.0, jnp.float32), operand=None)
-
-    eg = jnp.exp(g_cum).astype(jnp.float32)  # (C,) in (0,1]; safe (underflows to 0 OK)
-
-    # ============================================
-    # WY-style fast: Gram then A0, but NO D/D^{-1}
-    # ============================================
-    # G = (β K) @ K^T    (C×C), tiled over K
+    # ---------- Gram and A0 (strictly lower) ----------
     G = jnp.zeros((chunk_len, chunk_len), dtype=jnp.float32)
     n_kb = (K + BK - 1) // BK
 
     def gram_body(kb, G_cur):
         k0 = kb * BK
-        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))  # (C, BK)
-        kb_tile = k_tile * b_c[:, None]  # (C, BK) = βK
-        return G_cur + kb_tile @ jnp.transpose(k_tile)  # (C, C)
+        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
+        kb_tile = k_tile * b_c[:, None]  # βK
+        return G_cur + kb_tile @ jnp.transpose(k_tile)
 
     G = lax.fori_loop(0, n_kb, gram_body, G)
-    # A0 = - strictly-lower( G )
     A0 = -jnp.tril(G, k=-1)  # (C, C)
 
-    # ===========================
-    # yv_tile via forward-sub:   (I - Ā) U = βV
-    # where Ā[i,j] = A0[i,j] * exp(g_i - g_j)
-    # ===========================
+    # write A0 once per (NH, chunk) – only vt==0 writes
+    def _write_a0(_):
+        a0_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, chunk_len), dslice(0, chunk_len)] = A0[None, None, :, :]
+        return ()
+
+    _ = lax.cond(vt == 0, _write_a0, lambda _: (), operand=None)
+
+    # ---------- forward-sub yv (C×BV) ----------
     yv_tile = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
 
     def fs_v(i, Y):
@@ -1432,9 +1374,9 @@ def _gdn_chunk_fwd_kernel_fused(
 
         def acc_v(j, acc):
             aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-            decay_ij = jnp.exp(g_cum[i] - g_cum[j])
-            uj = lax.dynamic_slice(Y, (j, 0), (1, BV))[0]
-            return acc + (aij * decay_ij) * uj
+            decay = jnp.exp(g_cum[i] - g_cum[j])
+            yj = lax.dynamic_slice(Y, (j, 0), (1, BV))[0]
+            return acc + (aij * decay) * yj
 
         contrib = lax.fori_loop(0, i, acc_v, jnp.zeros((BV,), dtype=jnp.float32))
         yi = rhs_i + contrib
@@ -1442,10 +1384,8 @@ def _gdn_chunk_fwd_kernel_fused(
 
     yv_tile = lax.fori_loop(0, active, fs_v, yv_tile)
 
-    # ===========================
-    # yk_tile via forward-sub:   (I - Ā) W = e^{g} ⊙ (βK)
-    # ===========================
-    yk_tile = jnp.zeros((chunk_len, BK), dtype=jnp.float32)
+    # ---------- forward-sub yk (C×K) in BK tiles ----------
+    yk_tile = jnp.zeros((chunk_len, K), dtype=jnp.float32)
 
     def fs_k(kb, Y):
         k0 = kb * BK
@@ -1457,69 +1397,65 @@ def _gdn_chunk_fwd_kernel_fused(
 
             def acc_k(j, acc):
                 aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
-                decay_ij = jnp.exp(g_cum[i] - g_cum[j])
-                wj = lax.dynamic_slice(Ycur, (j, 0), (1, BK))[0]
-                return acc + (aij * decay_ij) * wj
+                decay = jnp.exp(g_cum[i] - g_cum[j])
+                yj = lax.dynamic_slice(Ycur, (j, k0), (1, BK))[0]
+                return acc + (aij * decay) * yj
 
             contrib = lax.fori_loop(0, i, acc_k, jnp.zeros((BK,), dtype=jnp.float32))
             yi = rhs_i + contrib
-            return lax.dynamic_update_slice(Ycur, yi[None, :], (i, 0))
+            return lax.dynamic_update_slice(Ycur, yi[None, :], (i, k0))
 
         return lax.fori_loop(0, active, fs_row, Y)
 
     yk_tile = lax.fori_loop(0, n_kb, fs_k, yk_tile)
 
-    # --- First pass accumulators using yk/yv as before ---
+    # ---------- pass 1 accumulators ----------
     v_prime = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
     inter = jnp.zeros((chunk_len, BV), dtype=jnp.float32)
     qk_raw = jnp.zeros((chunk_len, chunk_len), dtype=jnp.float32)
 
-    def body_k1_acc(kb, acc):
+    def pass1_body(kb, acc):
         vpr_acc, inter_acc, qk_acc = acc
         k0 = kb * BK
-        q_tile = lax.dynamic_slice(q_c, (0, k0), (chunk_len, BK))  # (C, BK)
-        # yk over this tile:
-        yk_t = lax.dynamic_slice(yk_tile, (0, 0), (chunk_len, BK))
-        S_kv = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))  # (BK, BV)
-        vpr_acc = vpr_acc + yk_t @ S_kv
-        inter_acc = inter_acc + (q_tile * eg[:, None]) @ S_kv
+        q_tile = lax.dynamic_slice(q_c, (0, k0), (chunk_len, BK))
+        yk_t = lax.dynamic_slice(yk_tile, (0, k0), (chunk_len, BK))
+        S_blk = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))
+        vpr_acc = vpr_acc + yk_t @ S_blk
+        inter_acc = inter_acc + (q_tile * eg[:, None]) @ S_blk
         qk_acc = qk_acc + q_tile @ jnp.transpose(lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK)))
         return (vpr_acc, inter_acc, qk_acc)
 
-    v_prime, inter, qk_raw = lax.fori_loop(0, n_kb, body_k1_acc, (v_prime, inter, qk_raw))
+    v_prime, inter, qk_raw = lax.fori_loop(0, n_kb, pass1_body, (v_prime, inter, qk_raw))
 
-    # --- Triangular "attention-like" mix with relative decays (unchanged) ---
-    decay = jnp.exp(g_cum[:, None] - g_cum[None, :])  # (C, C) in (0,1]
-    attn = jnp.tril(decay * qk_raw)  # (C, C)
+    decay = jnp.exp(g_cum[:, None] - g_cum[None, :])
+    attn = jnp.tril(decay * qk_raw)
 
-    v_new = yv_tile - v_prime  # (C, BV)
-    out = inter + attn @ v_new  # (C, BV)
+    v_new = yv_tile - v_prime
+    out = inter + attn @ v_new
 
-    # --- Update S for this V tile (unchanged) ---
-    alpha_tail = jnp.exp(g_tail).astype(jnp.float32)
-    dw = jnp.exp(g_tail - g_cum).astype(jnp.float32) * m  # (C,)
-    v_weighted = v_new * dw[:, None]  # (C, BV)
-
+    # ---------- state update ----------
+    dw = jnp.exp(g_tail - g_cum) * m
+    v_weighted = v_new * dw[:, None]
     S_add = jnp.zeros((K, BV), dtype=jnp.float32)
 
-    def body_k2(kb, S_acc):
+    def body_kb(kb, S_acc):
         k0 = kb * BK
-        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))  # (C, BK)
-        S_add_tile = jnp.transpose(k_tile) @ v_weighted  # (BK, BV)
+        k_tile = lax.dynamic_slice(k_c, (0, k0), (chunk_len, BK))
+        S_add_tile = jnp.transpose(k_tile) @ v_weighted
         return lax.dynamic_update_slice(S_acc, S_add_tile, (k0, 0))
 
-    S_add = lax.fori_loop(0, n_kb, body_k2, S_add)
+    S_add = lax.fori_loop(0, n_kb, body_kb, S_add)
 
-    def write_k3(kb, _):
+    def write_s(kb, _):
         k0 = kb * BK
-        S_prev_tile = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))  # (BK, BV)
-        S_new_tile = alpha_tail * S_prev_tile + lax.dynamic_slice(S_add, (k0, 0), (BK, BV))
-        s_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(k0, BK), dslice(0, BV)] = S_new_tile[None, None, :, :]
+        S_blk = lax.dynamic_slice(S_prev_v, (k0, 0), (BK, BV))
+        S_new_blk = alpha_tail * S_blk + lax.dynamic_slice(S_add, (k0, 0), (BK, BV))
+        s_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(k0, BK), dslice(0, BV)] = S_new_blk[None, None, :, :]
         return ()
 
-    _ = lax.fori_loop(0, n_kb, write_k3, ())
+    _ = lax.fori_loop(0, n_kb, write_s, ())
 
-    # --- Write out the chunk’s output for this V-tile ---
+    # write output tile
     out_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, chunk_len), dslice(0, BV)] = out.astype(out_tile_ref.dtype)[
         None, None, :, :
     ]
@@ -1538,10 +1474,11 @@ def _chunk_gated_delta_rule_flash_fused(
     use_qk_l2norm_in_kernel: bool = True,
     head_first: bool = False,
     lengths: Optional[jnp.ndarray] = None,
-    offsets: Optional[jnp.ndarray] = None,  # Optional: if provided, compute lengths
-    use_varlen: bool = False,  # keep existing flag for explicit control
+    offsets: Optional[jnp.ndarray] = None,
+    use_varlen: bool = False,
+    save_for_backward: bool = False,
 ):
-    # ----- reshape / layout -----
+    # ----- (unchanged) layout/flatten/pad/QK-norm -----
     if head_first:
         B, H, L, K = query.shape[:4]
         V = value.shape[-1]
@@ -1563,27 +1500,18 @@ def _chunk_gated_delta_rule_flash_fused(
     g_flat = g_bhl.reshape(NH, L).astype(jnp.float32)
     b_flat = b_bhl.reshape(NH, L).astype(jnp.float32)
 
-    # --- varlen: compute lengths_flat in tokens per NH sequence ---
     if use_varlen:
         if lengths is not None:
             lengths_flat = lengths.reshape(-1).astype(jnp.int32)
-            assert lengths_flat.shape[0] == NH
         elif offsets is not None:
-            # offsets can be NH or NH+1; if NH+1, do diff
             off = offsets.reshape(-1).astype(jnp.int32)
-            if off.shape[0] == NH + 1:
-                lengths_flat = off[1:] - off[:-1]
-            else:
-                lengths_flat = off
-            assert lengths_flat.shape[0] == NH
+            lengths_flat = off[1:] - off[:-1] if off.shape[0] == NH + 1 else off
         else:
             raise ValueError("use_varlen=True requires `lengths` or `offsets`.")
-        # Clip to [0, L] in case of over-reporting
         lengths_flat = jnp.clip(lengths_flat, 0, jnp.int32(L))
     else:
         lengths_flat = jnp.full((NH,), L, dtype=jnp.int32)
 
-    # Optional L2-norm + scaling (outside kernel)
     if use_qk_l2norm_in_kernel:
         eps = 1e-6
         qn = jnp.sqrt(jnp.sum(q_flat * q_flat, axis=-1, keepdims=True) + eps)
@@ -1601,13 +1529,8 @@ def _chunk_gated_delta_rule_flash_fused(
         pad = T_pad - w
         if pad == 0:
             return x
-        if x.ndim == 2:
-            return jnp.pad(x, ((0, 0), (0, pad)))
-        if x.ndim == 3:
-            return jnp.pad(x, ((0, 0), (0, pad), (0, 0)))
-        raise ValueError
+        return jnp.pad(x, ((0, 0), (0, pad))) if x.ndim == 2 else jnp.pad(x, ((0, 0), (0, pad), (0, 0)))
 
-    # Pad time to whole chunks; lengths remain in [0, L] and are used inside kernel
     q_flat = _pad_last(q_flat, L)
     k_flat = _pad_last(k_flat, L)
     v_flat = _pad_last(v_flat, L)
@@ -1625,14 +1548,16 @@ def _chunk_gated_delta_rule_flash_fused(
         S = jnp.zeros((NH, K, V_pad), dtype=jnp.float32)
     else:
         init = initial_state.astype(jnp.float32)
-        if init.ndim == 4:  # [B,H,K,V]
-            S = init.reshape(NH, K, init.shape[-1])
-        else:
-            S = init
+        S = init.reshape(NH, K, init.shape[-1]) if init.ndim == 4 else init
         if S.shape[-1] != V_pad:
             S = jnp.pad(S, ((0, 0), (0, 0), (0, V_pad - S.shape[-1])))
 
     out_pad = jnp.zeros((NH, T_pad, V_pad), dtype=value.dtype)
+    n_vtiles = V_pad // BV
+
+    # Buffers for backward
+    A0_buf = jnp.zeros((NH, Nc, C, C), dtype=jnp.float32) if save_for_backward else None
+    S_prev_buf = jnp.zeros((NH, Nc, K, V_pad), dtype=jnp.float32) if save_for_backward else None
 
     kernel = functools.partial(
         _gdn_chunk_fwd_kernel_fused,
@@ -1644,10 +1569,6 @@ def _chunk_gated_delta_rule_flash_fused(
         BV=int(BV),
     )
 
-    n_vtiles = V_pad // BV
-    # out_tile_struct = jax.ShapeDtypeStruct((NH, 1, C, BV), value.dtype)
-    # s_tile_struct = jax.ShapeDtypeStruct((NH, 1, K, BV), jnp.float32)
-
     in_specs = (
         pl.BlockSpec((1, T_pad, K), lambda nh, vt: (nh, 0, 0)),  # q
         pl.BlockSpec((1, T_pad, K), lambda nh, vt: (nh, 0, 0)),  # k
@@ -1655,24 +1576,30 @@ def _chunk_gated_delta_rule_flash_fused(
         pl.BlockSpec((1, T_pad), lambda nh, vt: (nh, 0)),  # g
         pl.BlockSpec((1, T_pad), lambda nh, vt: (nh, 0)),  # beta
         pl.BlockSpec((1, K, BV), lambda nh, vt: (nh, 0, vt * BV)),  # S_prev tile
-        pl.BlockSpec((1,), lambda nh, vt: (0,)),  # ci
-        pl.BlockSpec((1,), lambda nh, vt: (nh,)),
+        pl.BlockSpec((1,), lambda nh, vt: (0,)),  # ci (scalar)
+        pl.BlockSpec((1,), lambda nh, vt: (nh,)),  # lengths[nh]
     )
     out_specs = (
         pl.BlockSpec((1, 1, C, BV), lambda nh, vt: (nh, vt, 0, 0)),  # out tile
         pl.BlockSpec((1, 1, K, BV), lambda nh, vt: (nh, vt, 0, 0)),  # S tile
+        pl.BlockSpec((1, 1, C, C), lambda nh, vt: (nh, 0, 0, 0)),  # A0 tile (vt ignored; only vt==0 writes)
     )
 
     def one_chunk(carry, ci):
-        S_in, out_buf = carry
+        S_in, out_buf, A0_b, Sprev_b = carry
         ci_ary = jnp.asarray([ci], dtype=jnp.int32)
 
+        if save_for_backward:
+            # Save S_prev (whole V_pad) for this chunk (outside kernel; no tracers in index maps)
+            Sprev_b = Sprev_b.at[:, ci, :, :].set(S_in)
+
         with _fp32_mm():
-            out_tiles, s_tiles = pl.pallas_call(
+            out_tiles, s_tiles, a0_tiles = pl.pallas_call(
                 kernel,
                 out_shape=(
                     jax.ShapeDtypeStruct((NH, n_vtiles, C, BV), value.dtype),
                     jax.ShapeDtypeStruct((NH, n_vtiles, K, BV), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, n_vtiles, C, C), jnp.float32),
                 ),
                 grid=(NH, n_vtiles),
                 in_specs=in_specs,
@@ -1683,18 +1610,617 @@ def _chunk_gated_delta_rule_flash_fused(
         out_chunk = out_tiles.reshape(NH, C, n_vtiles * BV)[:, :, :V_pad]
         s_chunk = s_tiles.reshape(NH, K, n_vtiles * BV)[:, :, :V_pad]
 
+        if save_for_backward:
+            # Store A0 for this chunk (written only in vt==0)
+            A0_b = A0_b.at[:, ci, :, :].set(a0_tiles[:, 0, :, :])
+
         c0 = ci * C
         out_buf = lax.dynamic_update_slice(out_buf, out_chunk.astype(out_buf.dtype), (0, c0, 0))
         S_out = s_chunk
-        return (S_out, out_buf), None
+        return (S_out, out_buf, A0_b, Sprev_b), None
 
-    (S_final, out_all), _ = lax.scan(one_chunk, (S, out_pad), jnp.arange(Nc, dtype=jnp.int32))
+    (S_final, out_all, A0_buf, S_prev_buf), _ = lax.scan(
+        one_chunk,
+        (S, out_pad, A0_buf, S_prev_buf),
+        jnp.arange(Nc, dtype=jnp.int32),
+    )
 
     out_trim = out_all[:, :L, :V]
     out_bHLv = out_trim.reshape(B, H, L, V)
     out_named = out_bHLv if head_first else jnp.transpose(out_bHLv, (0, 2, 1, 3))
     S_ret = None if not output_final_state else S_final[:, :, :V].reshape(B, H, K, V)
-    return out_named, S_ret
+
+    # Return aux for backward
+    aux = (
+        {
+            "A0_buf": A0_buf,
+            "S_prev_buf": S_prev_buf,
+            "T_pad": T_pad,
+            "K": K,
+            "V_pad": V_pad,
+            "C": C,
+            "NH": NH,
+            "Nc": Nc,
+        }
+        if save_for_backward
+        else None
+    )
+
+    return out_named, S_ret, aux
+
+
+def _gdn_chunk_bwd_kernel_fused(
+    q_chunk_ref,  # [NH, C, K]
+    k_chunk_ref,  # [NH, C, K]
+    v_tile_ref,  # [NH, C, BV]
+    g_chunk_ref,  # [NH, C]
+    beta_chunk_ref,  # [NH, C]
+    a0_chunk_ref,  # [NH, C, C]
+    s_prev_tile_ref,  # [NH, K, BV]
+    dout_tile_ref,  # [NH, C, BV]
+    dS_in_tile_ref,  # [NH, K, BV]
+    lengths_chunk_ref,  # [NH]
+    dQ_chunk_ref,  # [NH, 1, C, K]
+    dK_chunk_ref,  # [NH, 1, C, K]
+    dV_tile_ref,  # [NH, 1, C, BV]
+    dG_chunk_ref,  # [NH, 1, C]
+    dB_chunk_ref,  # [NH, 1, C]
+    dS_out_tile_ref,  # [NH, K, BV]
+    *,
+    C: int,
+    K: int,
+    BV: int,
+):
+    nh = pl.program_id(0)
+
+    # ---- local views (all dynamic slicing, static sizes) ----
+    q_c = q_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, K)][0].astype(jnp.float32)
+    k_c = k_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, K)][0].astype(jnp.float32)
+    v_c = v_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)
+    g_c = g_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)
+    b_c = beta_chunk_ref[dslice(nh, 1), dslice(0, C)][0].astype(jnp.float32)
+    A0 = a0_chunk_ref[dslice(nh, 1), dslice(0, C), dslice(0, C)][0].astype(jnp.float32)
+    S_prev = s_prev_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)
+    dY = dout_tile_ref[dslice(nh, 1), dslice(0, C), dslice(0, BV)][0].astype(jnp.float32)
+    dS_in = dS_in_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)][0].astype(jnp.float32)
+    active = jnp.clip(lengths_chunk_ref[dslice(nh, 1)][0].astype(jnp.int32), 0, jnp.int32(C))
+
+    # row mask for varlen chunk
+    m = (lax.iota(jnp.int32, C) < active).astype(jnp.float32)
+    q_c = q_c * m[:, None]
+    k_c = k_c * m[:, None]
+    v_c = v_c * m[:, None]
+    b_c = b_c * m
+
+    g_cum = jnp.cumsum(g_c, axis=0)
+    eg = jnp.exp(g_cum)
+    g_tail = lax.cond(
+        active > 0,
+        lambda _: lax.dynamic_slice_in_dim(g_cum, active - 1, 1, axis=0)[0],
+        lambda _: jnp.array(0.0, jnp.float32),
+        operand=None,
+    )
+    alpha_tail = jnp.exp(g_tail)
+
+    # ---------- Re-solve yv, yk using saved A0 (forward-sub, bounded by active) ----------
+    def fs_yv():
+        Y = jnp.zeros((C, BV), jnp.float32)
+
+        def row(i, Ycur):
+            rhs_i = b_c[i] * lax.dynamic_slice(v_c, (i, 0), (1, BV))[0]
+
+            def acc_j(j, acc):
+                aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+                decay = jnp.exp(g_cum[i] - g_cum[j])
+                yj = lax.dynamic_slice(Ycur, (j, 0), (1, BV))[0]
+                return acc + (aij * decay) * yj
+
+            contrib = lax.fori_loop(0, i, acc_j, jnp.zeros((BV,), jnp.float32))
+            yi = rhs_i + contrib
+            return lax.dynamic_update_slice(Ycur, yi[None, :], (i, 0))
+
+        return lax.fori_loop(0, active, row, Y)
+
+    yv = fs_yv()
+
+    def fs_yk():
+        Y = jnp.zeros((C, K), jnp.float32)
+
+        def row(i, Ycur):
+            rhs_i = (eg[i] * b_c[i]) * lax.dynamic_slice(k_c, (i, 0), (1, K))[0]
+
+            def acc_j(j, acc):
+                aij = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+                decay = jnp.exp(g_cum[i] - g_cum[j])
+                yj = lax.dynamic_slice(Ycur, (j, 0), (1, K))[0]
+                return acc + (aij * decay) * yj
+
+            contrib = lax.fori_loop(0, i, acc_j, jnp.zeros((K,), jnp.float32))
+            yi = rhs_i + contrib
+            return lax.dynamic_update_slice(Ycur, yi[None, :], (i, 0))
+
+        return lax.fori_loop(0, active, row, Y)
+
+    yk = fs_yk()
+
+    v_prime = yk @ S_prev
+    v_new = yv - v_prime
+
+    qk = q_c @ jnp.transpose(k_c)
+    decay = jnp.exp(g_cum[:, None] - g_cum[None, :])
+    tril_mask = jnp.tril(jnp.ones((C, C), jnp.float32))
+    M = decay * tril_mask
+    attn = M * qk
+    # inter = (q_c * eg[:, None]) @ S_prev
+
+    # ---------- Backprop ----------
+    # out = inter + attn @ v_new
+    dQ_inter = (dY @ jnp.transpose(S_prev)) * eg[:, None]
+    dS_prev_local = jnp.transpose(q_c * eg[:, None]) @ dY
+    inner = jnp.sum((dY @ jnp.transpose(S_prev)) * q_c, axis=-1)
+    dgc_inter = inner * eg
+
+    dAttn = dY @ jnp.transpose(v_new)
+    dv_new = jnp.transpose(attn) @ dY
+    d_qk = M * dAttn
+    dQ_attn = d_qk @ k_c
+    dK_attn = jnp.transpose(d_qk) @ q_c
+    W = (qk * dAttn) * tril_mask
+    dgc_attn = jnp.sum(W, axis=1) - jnp.sum(W, axis=0)
+
+    # v_new = yv - yk @ S_prev
+    dyv = dv_new
+    dyk = -(dv_new @ jnp.transpose(S_prev))
+    dS_prev_local = dS_prev_local - jnp.transpose(yk) @ dv_new
+
+    # cross-chunk carry: S_out = alpha_tail * S_prev + sum_i (exp(g_tail - g_cum[i]) k_i v_new[i]^T)
+    w = jnp.exp(g_tail - g_cum) * m  # (C,)
+    kv_dS = k_c @ dS_in  # (C, BV)
+    dv_new = dv_new + kv_dS * w[:, None]  # (C, BV)
+
+    # dK from carry: for each row i, dK_i += w_i * (dS_in @ v_new_i)
+    dK_add = ((dS_in @ jnp.transpose(v_new)).T) * w[:, None]  # (C, K)
+
+    dgt_from_alpha = alpha_tail * jnp.sum(S_prev * dS_in)
+    s_i = jnp.sum(kv_dS * v_new, axis=-1)  # (C,)
+    dgt_from_w = jnp.sum(w * s_i)
+    dgc_from_w = -w * s_i
+
+    # SAFE update at tail index (active-1) without Python if:
+    def _add_tail(_):
+        idx = active - jnp.int32(1)
+        base = dgc_from_w
+        cur = lax.dynamic_slice_in_dim(base, idx, 1, axis=0)[0]
+        upd = cur + (dgt_from_alpha + dgt_from_w)
+        return lax.dynamic_update_slice_in_dim(base, upd[None], idx, axis=0)
+
+    dgc_carry = lax.cond(active > 0, _add_tail, lambda _: dgc_from_w, operand=None)
+    dS_prev_carry = alpha_tail * dS_in
+
+    # backward triangular solved contributions (Ā) for yv/yk
+    def bwd_sub_yv():
+        d_rhs = jnp.zeros((C, BV), jnp.float32)
+        dAbar = jnp.zeros((C, C), jnp.float32)
+
+        def row_rev(i_rev, state):
+            d_rhs_cur, dA = state
+            i = active - 1 - i_rev
+            dyi = lax.dynamic_slice(dyv, (i, 0), (1, BV))[0]
+            d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, dyi[None, :], (i, 0))
+
+            def upd_j(j, carry):
+                dA_cur, d_rhs_inner = carry
+                aij0 = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+                decay = jnp.exp(g_cum[i] - g_cum[j])
+                yj = lax.dynamic_slice(yv, (j, 0), (1, BV))[0]
+                # dAbar[i,j] += <dyi, yj>
+                val = lax.dynamic_slice(dA_cur, (i, j), (1, 1))[0, 0] + jnp.sum(dyi * yj)
+                dA_cur = lax.dynamic_update_slice(dA_cur, jnp.asarray([[val]], jnp.float32), (i, j))
+                d_rhs_inner = lax.dynamic_update_slice(
+                    d_rhs_inner,
+                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, BV))[0] + (aij0 * decay) * dyi)[None, :],
+                    (j, 0),
+                )
+                return (dA_cur, d_rhs_inner)
+
+            dA, d_rhs_cur = lax.fori_loop(0, i, upd_j, (dA, d_rhs_cur))
+            return (d_rhs_cur, dA)
+
+        return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
+
+    d_rhs_v, dAbar_v = bwd_sub_yv()
+
+    def bwd_sub_yk():
+        d_rhs = jnp.zeros((C, K), jnp.float32)
+        dAbar = jnp.zeros((C, C), jnp.float32)
+
+        def row_rev(i_rev, state):
+            d_rhs_cur, dA = state
+            i = active - 1 - i_rev
+            dyi = lax.dynamic_slice(dyk, (i, 0), (1, K))[0]
+            d_rhs_cur = lax.dynamic_update_slice(d_rhs_cur, dyi[None, :], (i, 0))
+
+            def upd_j(j, carry):
+                dA_cur, d_rhs_inner = carry
+                aij0 = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+                decay = jnp.exp(g_cum[i] - g_cum[j])
+                yj = lax.dynamic_slice(yk, (j, 0), (1, K))[0]
+                val = lax.dynamic_slice(dA_cur, (i, j), (1, 1))[0, 0] + jnp.sum(dyi * yj)
+                dA_cur = lax.dynamic_update_slice(dA_cur, jnp.asarray([[val]], jnp.float32), (i, j))
+                d_rhs_inner = lax.dynamic_update_slice(
+                    d_rhs_inner,
+                    (lax.dynamic_slice(d_rhs_inner, (j, 0), (1, K))[0] + (aij0 * decay) * dyi)[None, :],
+                    (j, 0),
+                )
+                return (dA_cur, d_rhs_inner)
+
+            dA, d_rhs_cur = lax.fori_loop(0, i, upd_j, (dA, d_rhs_cur))
+            return (d_rhs_cur, dA)
+
+        return lax.fori_loop(0, active, row_rev, (d_rhs, dAbar))
+
+    d_rhs_k, dAbar_k = bwd_sub_yk()
+
+    dAbar = dAbar_v + dAbar_k
+
+    # map dAbar → dA0 and d g_cum
+    dA0 = jnp.zeros_like(A0)
+    dgc_from_A = jnp.zeros((C,), jnp.float32)
+
+    def tri_map(i, carry):
+        dA0_cur, dgc_cur = carry
+
+        def col(j, inner):
+            dA0_i, dgc_i = inner
+            aij0 = lax.dynamic_slice(A0, (i, j), (1, 1))[0, 0]
+            decay = jnp.exp(g_cum[i] - g_cum[j])
+            dAij = lax.dynamic_slice(dAbar, (i, j), (1, 1))[0, 0]
+            # dA0 += dAbar * decay
+            val = lax.dynamic_slice(dA0_i, (i, j), (1, 1))[0, 0] + dAij * decay
+            dA0_i = lax.dynamic_update_slice(dA0_i, jnp.asarray([[val]], jnp.float32), (i, j))
+            # g_cum: + on i, - on j
+            dgc_i = dgc_i.at[i].add(dAij * aij0 * decay)
+            dgc_i = dgc_i.at[j].add(-dAij * aij0 * decay)
+            return (dA0_i, dgc_i)
+
+        return lax.fori_loop(0, i, col, (dA0_cur, dgc_cur))
+
+    dA0, dgc_from_A = lax.fori_loop(1, active, tri_map, (dA0, dgc_from_A))
+
+    # RHS contributions
+    dV_tile = b_c[:, None] * d_rhs_v
+    dB_from_v = jnp.sum(v_c * d_rhs_v, axis=-1)
+    dK_rhs = (eg[:, None] * b_c[:, None]) * d_rhs_k
+    dB_from_k = jnp.sum((eg[:, None] * k_c) * d_rhs_k, axis=-1)
+    dgc_from_rhs_k = eg * jnp.sum((b_c[:, None] * k_c) * d_rhs_k, axis=-1)
+
+    # dA0 → dK and dβ, via A0[i,j] = -β_i <k_i, k_j>
+    dK_from_A0 = jnp.zeros_like(k_c)
+    dB_from_A0 = jnp.zeros((C,), jnp.float32)
+
+    def gram_bwd(i, state):
+        dK_acc, dB_acc = state
+        ki = lax.dynamic_slice(k_c, (i, 0), (1, K))[0]
+
+        def body(j, carry):
+            dK_a, dB_a = carry
+            kj = lax.dynamic_slice(k_c, (j, 0), (1, K))[0]
+            coeff = -(dA0[i, j] * b_c[i])
+            dK_a = dK_a.at[i, :].add(coeff * kj)
+            dK_a = dK_a.at[j, :].add(coeff * ki)
+            dB_a = dB_a + (-dA0[i, j]) * jnp.sum(ki * kj)
+            return (dK_a, dB_a)
+
+        return lax.fori_loop(0, i, body, (dK_acc, dB_acc))
+
+    dK_from_A0, dB_from_A0 = lax.fori_loop(1, active, gram_bwd, (dK_from_A0, dB_from_A0))
+
+    # collect per-chunk grads
+    dQ_tile = dQ_inter + dQ_attn
+    dK_tile = dK_attn + dK_add + dK_rhs + dK_from_A0
+    dB_tile = (dB_from_v + dB_from_k + dB_from_A0) * m
+    dgc_total = (dgc_inter + dgc_attn + dgc_from_A + dgc_from_rhs_k + dgc_carry) * m
+
+    # reverse-cumsum d g_cum → d g, avoiding dynamic jnp.pad
+    def rev_cumsum_full(x):
+        # returns length-C vector; only positions < active are written
+        def body(i_rev, carry):
+            acc, out_vec = carry
+            i = active - jnp.int32(1) - i_rev
+            xi = lax.dynamic_slice_in_dim(x, i, 1, axis=0)[0]
+            acc = acc + xi
+            out_vec = lax.dynamic_update_slice_in_dim(out_vec, acc[None], i, axis=0)
+            return (acc, out_vec)
+
+        init = (jnp.array(0.0, jnp.float32), jnp.zeros((C,), jnp.float32))
+        _, out_vec = lax.fori_loop(0, active, body, init)
+        return out_vec
+
+    dG_tile = rev_cumsum_full(dgc_total)
+
+    dS_out = dS_prev_local + dS_prev_carry
+
+    # writes
+    dQ_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dQ_tile[None, None, :, :]
+    dK_chunk_ref[dslice(nh, 1), dslice(0, 1), dslice(0, C), dslice(0, K)] = dK_tile[None, None, :, :]
+    dV_tile_ref[dslice(nh, 1), dslice(0, 1), dslice(0, BV)] = dV_tile[None, None, :, :]
+    dG_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dG_tile[None, None, :]
+    dB_chunk_ref[dslice(nh, 1), dslice(0, 1)] = dB_tile[None, None, :]
+    dS_out_tile_ref[dslice(nh, 1), dslice(0, K), dslice(0, BV)] = dS_out[None, :, :]
+
+
+def _chunk_gated_delta_rule_flash_bwd_fused(
+    q_arr,
+    k_arr,
+    v_arr,
+    g_arr,
+    beta_arr,
+    d_out_arr,
+    *,
+    head_first: bool,
+    lengths,
+    aux,
+    initial_state_was_none: bool,
+    use_qk_l2norm_in_kernel: bool,
+):
+    A0_buf = aux["A0_buf"]
+    S_prev_buf = aux["S_prev_buf"]
+    T_pad = int(aux["T_pad"])  # padded time length used in fwd
+    K = int(aux["K"])
+    V_pad = int(aux["V_pad"])  # padded value dim used in fwd
+    C = int(aux["C"])
+    NH = int(aux["NH"])
+    Nc = int(aux["Nc"])
+
+    # ---------- helpers: pad along time and value ----------
+    def _pad_time(x, t_pad):
+        """Pad axis=1 (time) of an NH-major array to t_pad."""
+        t = x.shape[1]
+        if t == t_pad:
+            return x
+        return jnp.pad(x, ((0, 0), (0, t_pad - t)) + ((0, 0),) * (x.ndim - 2))
+
+    def _pad_time_and_feat(x, t_pad, v_pad):
+        """Pad axis=1 (time) to t_pad and last axis (value) to v_pad."""
+        t, v = x.shape[1], x.shape[-1]
+        if t != t_pad:
+            x = jnp.pad(x, ((0, 0), (0, t_pad - t)) + ((0, 0),) * (x.ndim - 2))
+        if v != v_pad:
+            x = jnp.pad(x, ((0, 0), (0, 0)) + ((0, v_pad - v),))
+        return x
+
+    # ---------- layout-normalize inputs to NH-major and pad to T_pad/V_pad ----------
+    if head_first:
+        # q,k: [B,H,L,K]  → [NH, L, K]
+        B, H, L, _K = q_arr.shape
+        _ = _K  # silence lints
+        q_LK = jnp.transpose(q_arr, (0, 2, 1, 3)).reshape(NH, L, K)
+        k_LK = jnp.transpose(k_arr, (0, 2, 1, 3)).reshape(NH, L, K)
+        # v: [B,H,L,V]   → [NH, L, V]
+        V = v_arr.shape[-1]
+        v_LV = jnp.transpose(v_arr, (0, 2, 1, 3)).reshape(NH, L, V)
+        # g,b: [B,H,L]   → [NH, L]
+        g_L = jnp.transpose(g_arr, (0, 2, 1)).reshape(NH, L)
+        b_L = jnp.transpose(beta_arr, (0, 2, 1)).reshape(NH, L)
+        # dY: [B,H,L,V]  → [NH, L, V]
+        dY_LV = jnp.transpose(d_out_arr, (0, 2, 1, 3)).reshape(NH, L, V)
+    else:
+        # q,k: [B,L,H,K] → [NH, L, K]
+        B, L, H, _K = q_arr.shape
+        _ = _K
+        q_LK = q_arr.reshape(NH, L, K)
+        k_LK = k_arr.reshape(NH, L, K)
+        # v: [B,L,H,V]   → [NH, L, V]
+        V = v_arr.shape[-1]
+        v_LV = v_arr.reshape(NH, L, V)
+        # g,b: [B,L,H]   → [NH, L]
+        g_L = g_arr.reshape(NH, L)
+        b_L = beta_arr.reshape(NH, L)
+        # dY: [B,L,H,V]  → [NH, L, V]
+        dY_LV = d_out_arr.reshape(NH, L, V)
+
+    # === PAD to T_pad / V_pad so chunk slicing works for the last chunk ===
+    q_flat = _pad_time(q_LK, T_pad).astype(jnp.float32)  # [NH, T_pad, K]
+    k_flat = _pad_time(k_LK, T_pad).astype(jnp.float32)  # [NH, T_pad, K]
+    g_flat = _pad_time(g_L, T_pad).astype(jnp.float32)  # [NH, T_pad]
+    b_flat = _pad_time(b_L, T_pad).astype(jnp.float32)  # [NH, T_pad]
+    v_flat = _pad_time_and_feat(v_LV, T_pad, V_pad).astype(jnp.float32)  # [NH, T_pad, V_pad]
+    dY_full = _pad_time_and_feat(dY_LV, T_pad, V_pad).astype(jnp.float32)  # [NH, T_pad, V_pad]
+
+    # ---------- init grads ----------
+    dQ_flat = jnp.zeros_like(q_flat, dtype=jnp.float32)
+    dK_flat = jnp.zeros_like(k_flat, dtype=jnp.float32)
+    dV_flat = jnp.zeros_like(v_flat, dtype=jnp.float32)
+    dG_flat = jnp.zeros_like(g_flat, dtype=jnp.float32)
+    dB_flat = jnp.zeros_like(b_flat, dtype=jnp.float32)
+
+    # lengths per NH
+    if lengths is None:
+        lengths_flat = jnp.full((NH,), T_pad, dtype=jnp.int32)
+    else:
+        lf = lengths.astype(jnp.int32)
+        lf = lf.reshape(-1) if lf.ndim == 2 else lf
+        lengths_flat = jnp.clip(lf, 0, jnp.int32(T_pad))
+
+    BV = min(64 if V_pad >= 128 else 32, V_pad)
+    n_vtiles = V_pad // BV
+
+    # reverse carry dS (NH, K, V_pad)
+    dS_carry = jnp.zeros((NH, K, V_pad), dtype=jnp.float32)
+
+    kernel = functools.partial(
+        _gdn_chunk_bwd_kernel_fused,
+        C=int(C),
+        K=int(K),
+        BV=int(BV),
+    )
+
+    # ---------- reverse over chunks ----------
+    def one_chunk(ci, dS_in):
+        c0 = ci * C
+        lengths_chunk = jnp.clip(lengths_flat - jnp.int32(c0), 0, jnp.int32(C))  # [NH]
+
+        # slice per-chunk tensors OUTSIDE the kernel (static sizes inside)
+        q_chunk = jax.lax.dynamic_slice(q_flat, (0, c0, 0), (NH, C, K))
+        k_chunk = jax.lax.dynamic_slice(k_flat, (0, c0, 0), (NH, C, K))
+        g_chunk = jax.lax.dynamic_slice(g_flat, (0, c0), (NH, C))
+        b_chunk = jax.lax.dynamic_slice(b_flat, (0, c0), (NH, C))
+        A0_chunk = jax.lax.dynamic_slice(A0_buf, (0, ci, 0, 0), (NH, 1, C, C)).squeeze(1)
+        dY_chunk = jax.lax.dynamic_slice(dY_full, (0, c0, 0), (NH, C, V_pad))
+        S_prev_chunk = jax.lax.dynamic_slice(S_prev_buf, (0, ci, 0, 0), (NH, 1, K, V_pad)).squeeze(1)
+
+        # per-chunk accumulators
+        dQ_c = jnp.zeros((NH, C, K), jnp.float32)
+        dK_c = jnp.zeros((NH, C, K), jnp.float32)
+        dV_c = jnp.zeros((NH, C, V_pad), jnp.float32)
+        dG_c = jnp.zeros((NH, C), jnp.float32)
+        dB_c = jnp.zeros((NH, C), jnp.float32)
+
+        def one_vt(vt, acc):
+            dQ_acc, dK_acc, dV_acc, dG_acc, dB_acc, dS_in_prev = acc
+
+            v_tile = jax.lax.dynamic_slice(v_flat, (0, c0, vt * BV), (NH, C, BV))
+            dY_tile = jax.lax.dynamic_slice(dY_chunk, (0, 0, vt * BV), (NH, C, BV))
+            S_prev_t = jax.lax.dynamic_slice(S_prev_chunk, (0, 0, vt * BV), (NH, K, BV))
+            dS_in_t = jax.lax.dynamic_slice(dS_in, (0, 0, vt * BV), (NH, K, BV))
+
+            dQ_t, dK_t, dV_t, dG_t, dB_t, dS_out_t = pl.pallas_call(
+                kernel,
+                out_shape=(
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, 1, C, K), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, 1, C, BV), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, 1, C), jnp.float32),
+                    jax.ShapeDtypeStruct((NH, K, BV), jnp.float32),
+                ),
+                grid=(NH,),
+                in_specs=(
+                    pl.BlockSpec((1, C, K), lambda nh: (nh, 0, 0)),  # q_chunk
+                    pl.BlockSpec((1, C, K), lambda nh: (nh, 0, 0)),  # k_chunk
+                    pl.BlockSpec((1, C, BV), lambda nh: (nh, 0, 0)),  # v_tile
+                    pl.BlockSpec((1, C), lambda nh: (nh, 0)),  # g_chunk
+                    pl.BlockSpec((1, C), lambda nh: (nh, 0)),  # b_chunk
+                    pl.BlockSpec((1, C, C), lambda nh: (nh, 0, 0)),  # A0_chunk
+                    pl.BlockSpec((1, K, BV), lambda nh: (nh, 0, 0)),  # S_prev_tile
+                    pl.BlockSpec((1, C, BV), lambda nh: (nh, 0, 0)),  # dY_tile
+                    pl.BlockSpec((1, K, BV), lambda nh: (nh, 0, 0)),  # dS_in_tile
+                    pl.BlockSpec((1,), lambda nh: (nh,)),  # lengths_chunk
+                ),
+                out_specs=(
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, K), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C, BV), lambda nh: (nh, 0, 0, 0)),
+                    pl.BlockSpec((1, 1, C), lambda nh: (nh, 0, 0)),
+                    pl.BlockSpec((1, 1, C), lambda nh: (nh, 0, 0)),
+                    pl.BlockSpec((1, K, BV), lambda nh: (nh, 0, 0)),
+                ),
+                interpret=_should_interpret_pallas(),
+            )(q_chunk, k_chunk, v_tile, g_chunk, b_chunk, A0_chunk, S_prev_t, dY_tile, dS_in_t, lengths_chunk)
+
+            dQ_acc = dQ_acc + dQ_t[:, 0, :, :]
+            dK_acc = dK_acc + dK_t[:, 0, :, :]
+
+            start = vt * jnp.int32(BV)
+
+            dv_old = lax.dynamic_slice(dV_acc, (0, 0, start), (NH, C, BV))
+            dv_new = dv_old + dV_t[:, 0, :, :]
+            dV_acc = lax.dynamic_update_slice(dV_acc, dv_new, (0, 0, start))
+
+            dG_acc = dG_acc + dG_t[:, 0, :]
+            dB_acc = dB_acc + dB_t[:, 0, :]
+            dS_in_prev = lax.dynamic_update_slice(dS_in_prev, dS_out_t, (0, 0, start))
+            return (dQ_acc, dK_acc, dV_acc, dG_acc, dB_acc, dS_in_prev)
+
+        dQ_c, dK_c, dV_c, dG_c, dB_c, dS_out = lax.fori_loop(
+            0, n_vtiles, one_vt, (dQ_c, dK_c, dV_c, dG_c, dB_c, jnp.zeros_like(dS_in))
+        )
+
+        # scatter per-chunk grads
+        old = lax.dynamic_slice(dQ_flat, (0, c0, 0), (NH, C, K))
+        dQ_sc = lax.dynamic_update_slice(dQ_flat, old + dQ_c, (0, c0, 0))
+
+        old = lax.dynamic_slice(dK_flat, (0, c0, 0), (NH, C, K))
+        dK_sc = lax.dynamic_update_slice(dK_flat, old + dK_c, (0, c0, 0))
+
+        old = lax.dynamic_slice(dV_flat, (0, c0, 0), (NH, C, V_pad))
+        dV_sc = lax.dynamic_update_slice(dV_flat, old + dV_c, (0, c0, 0))
+
+        old = lax.dynamic_slice(dG_flat, (0, c0), (NH, C))
+        dG_sc = lax.dynamic_update_slice(dG_flat, old + dG_c, (0, c0))
+
+        old = lax.dynamic_slice(dB_flat, (0, c0), (NH, C))
+        dB_sc = lax.dynamic_update_slice(dB_flat, old + dB_c, (0, c0))
+        return (dQ_sc, dK_sc, dV_sc, dG_sc, dB_sc, dS_out)
+
+    # fold over chunks in reverse: Nc-1 .. 0
+    def rev_chunks(carry, i):
+        dQ_c, dK_c, dV_c, dG_c, dB_c, dS_in = carry
+        ci = jnp.int32(Nc - 1 - i)
+        dQ_c, dK_c, dV_c, dG_c, dB_c, dS_in = one_chunk(ci, dS_in)
+        return (dQ_c, dK_c, dV_c, dG_c, dB_c, dS_in), None
+
+    (dQ_flat, dK_flat, dV_flat, dG_flat, dB_flat, dS0), _ = lax.scan(
+        rev_chunks,
+        (dQ_flat, dK_flat, dV_flat, dG_flat, dB_flat, dS_carry),
+        jnp.arange(Nc, dtype=jnp.int32),
+    )
+
+    # ---------- pack back to original layout & trim to L,V ----------
+    # Reconstruct NH-major raw q,k (unpadded), then pad to T_pad to match dQ_flat/dK_flat
+    if head_first:
+        B, H = v_arr.shape[0], v_arr.shape[1] if v_arr.ndim == 4 else (q_arr.shape[0], k_arr.shape[2])
+        # From earlier layout branch, we already have B, L, H, K above
+        q_LK_raw = (jnp.transpose(q_arr, (0, 2, 1, 3))).reshape(aux["NH"], -1, aux["K"]).astype(jnp.float32)
+        k_LK_raw = (jnp.transpose(k_arr, (0, 2, 1, 3))).reshape(aux["NH"], -1, aux["K"]).astype(jnp.float32)
+    else:
+        # q_arr: [B, L, H, K] -> [NH, L, K]
+        NH = aux["NH"]
+        K = aux["K"]
+        L = q_arr.shape[1]
+        q_LK_raw = q_arr.reshape(NH, L, K).astype(jnp.float32)
+        k_LK_raw = k_arr.reshape(NH, L, K).astype(jnp.float32)
+
+    q_raw_flat = _pad_time(q_LK_raw, aux["T_pad"])
+    k_raw_flat = _pad_time(k_LK_raw, aux["T_pad"])
+
+    if use_qk_l2norm_in_kernel:
+        eps = jnp.asarray(1e-6, jnp.float32)
+
+        def _l2norm_bwd(dY, X, scale):
+            # d/ dX ( (X / ||X||) * scale ) applied to row-vectors along last dim
+            inv = lax.rsqrt(jnp.sum(X * X, axis=-1, keepdims=True) + eps)
+            dot = jnp.sum(dY * X, axis=-1, keepdims=True)
+            return scale * (inv * dY + (-(inv**3.0)) * X * dot)
+
+        scale_q = jnp.asarray(aux["K"] ** -0.5, jnp.float32)
+        dQ_flat_raw = _l2norm_bwd(dQ_flat, q_raw_flat, scale_q)
+        dK_flat_raw = _l2norm_bwd(dK_flat, k_raw_flat, jnp.asarray(1.0, jnp.float32))
+    else:
+        # Only the 1/sqrt(K) scaling was applied to q in forward
+        scale_q = jnp.asarray(aux["K"] ** -0.5, jnp.float32)
+        dQ_flat_raw = dQ_flat * scale_q
+        dK_flat_raw = dK_flat
+
+    # From here on, use *raw* grads
+    dQ_flat = dQ_flat_raw
+    dK_flat = dK_flat_raw
+
+    if head_first:
+        dq = jnp.transpose(dQ_flat.reshape(B, H, T_pad, K)[:, :, :L, :], (0, 2, 1, 3))
+        dk = jnp.transpose(dK_flat.reshape(B, H, T_pad, K)[:, :, :L, :], (0, 2, 1, 3))
+        dv = jnp.transpose(dV_flat[:, :L, : v_arr.shape[-1]].reshape(B, H, L, v_arr.shape[-1]), (0, 2, 1, 3))
+        dg = jnp.transpose(dG_flat[:, :L].reshape(B, H, L), (0, 2, 1))
+        db = jnp.transpose(dB_flat[:, :L].reshape(B, H, L), (0, 2, 1))
+    else:
+        dq = dQ_flat[:, :L, :].reshape(B, L, H, K)
+        dk = dK_flat[:, :L, :].reshape(B, L, H, K)
+        dv = dV_flat[:, :L, : v_arr.shape[-1]].reshape(B, L, H, v_arr.shape[-1])
+        dg = dG_flat[:, :L].reshape(B, L, H)
+        db = dB_flat[:, :L].reshape(B, L, H)
+
+    d_initial_state = None if initial_state_was_none else dS0.reshape(B, -1, K, V_pad)[:, :H, :, : v_arr.shape[-1]]
+    return dq, dk, dv, dg, db, d_initial_state
 
 
 # ---------------------------------------------------------------------------
@@ -1717,45 +2243,44 @@ def _chunk_gated_delta_rule_flash_fused(
 @functools.partial(
     jax.custom_vjp,
     nondiff_argnums=(
-        8,  # chunk_size (int)
-        9,  # output_final_state (bool)
-        10,  # use_qk_l2norm_in_kernel (bool)
-        11,  # head_first (bool)
-        12,  # use_varlen (bool)
+        8,  # chunk_size
+        9,  # output_final_state
+        10,  # use_qk_l2norm_in_kernel
+        11,  # head_first
+        12,  # use_varlen
     ),
 )
-def _chunk_gated_delta_rule_flash_call(
-    q_arr: jnp.ndarray,  # [B, L, H, K] if head_first=False; else [B, H, L, K]
-    k_arr: jnp.ndarray,  # same layout as q_arr
-    v_arr: jnp.ndarray,  # [B, L, H, V] or [B, H, L, V]
-    g_arr: jnp.ndarray,  # [B, L, H]     or [B, H, L]
-    beta_arr: jnp.ndarray,  # [B, L, H]     or [B, H, L]
-    lengths: Optional[jnp.ndarray],  # shape [B, H] or [B*H], or None ⇒ full length
-    offsets: Optional[jnp.ndarray],  # unused here; keep for API compatibility
-    initial_state: Optional[jnp.ndarray],  # normally None for train/prefill
-    chunk_size: int,
-    output_final_state: bool,
-    use_qk_l2norm_in_kernel: bool,
-    head_first: bool,
-    use_varlen: bool,
+def _chunk_gated_delta_rule_flash(
+    q_arr,
+    k_arr,
+    v_arr,
+    g_arr,
+    beta_arr,
+    lengths,
+    offsets,
+    initial_state,
+    chunk_size,
+    output_final_state,
+    use_qk_l2norm_in_kernel,
+    head_first,
+    use_varlen,
 ):
-    # Forward simply defers to the fused Pallas implementation.
-    with _fp32_mm():
-        out_arr, final_state = _chunk_gated_delta_rule_flash_fused(
-            q_arr,
-            k_arr,
-            v_arr,
-            g_arr,
-            beta_arr,
-            chunk_size=chunk_size,
-            initial_state=initial_state,
-            output_final_state=output_final_state,
-            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-            head_first=head_first,
-            lengths=lengths,
-            offsets=offsets,
-            use_varlen=use_varlen,
-        )
+    out_arr, final_state, _ = _chunk_gated_delta_rule_flash_fused(
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        chunk_size=chunk_size,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        head_first=head_first,
+        lengths=lengths,
+        offsets=offsets,
+        use_varlen=use_varlen,
+        save_for_backward=False,  # plain call (used by export or when no grads)
+    )
     return (out_arr, final_state)
 
 
@@ -1774,7 +2299,7 @@ def _chunk_gated_delta_rule_flash_call_fwd(
     head_first,
     use_varlen,
 ):
-    out_arr, final_state = _chunk_gated_delta_rule_flash_fused(
+    out_arr, final_state, aux = _chunk_gated_delta_rule_flash_fused(
         q_arr,
         k_arr,
         v_arr,
@@ -1788,19 +2313,11 @@ def _chunk_gated_delta_rule_flash_call_fwd(
         lengths=lengths,
         offsets=offsets,
         use_varlen=use_varlen,
+        save_for_backward=True,  # <-- save A0/S_prev for bwd
     )
-
-    # IMPORTANT: store initial_state in residuals so bwd can compute dS0
-    res = (
-        q_arr,
-        k_arr,
-        v_arr,
-        g_arr,
-        beta_arr,
-        lengths,  # may be None
-        head_first,  # layout flag
-        initial_state,  # may be None; needed for dS0
-    )
+    # Residuals for bwd (arrays only; no Python captures)
+    initial_state_was_none = initial_state is None
+    res = (q_arr, k_arr, v_arr, g_arr, beta_arr, lengths, head_first, initial_state_was_none, aux)
     return (out_arr, final_state), res
 
 
@@ -1809,105 +2326,35 @@ def _chunk_gated_delta_rule_flash_call_bwd(
     output_final_state,
     use_qk_l2norm_in_kernel,
     head_first,
-    use_varlen,  # 5 static args
+    use_varlen,
     res,
     cotangents,
 ):
-    # Unpack residuals
-    q_arr, k_arr, v_arr, g_arr, beta_arr, lengths, head_first_res, initial_state_arr = res
-    d_out_arr, d_final_state = cotangents  # we ignore d(final_state) in this pass
+    q_arr, k_arr, v_arr, g_arr, beta_arr, lengths, head_first_res, initial_state_was_none, aux = res
+    d_out_arr, _d_final_state = cotangents  # we ignore d(final_state)
 
-    # Build NamedArrays for the reference VJP (canonical [B, L, H, *] layout)
-    if not head_first:
-        B, L, H, K = q_arr.shape
-        V = v_arr.shape[-1]
-        q_named = hax.named(q_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)))
-        k_named = hax.named(k_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)))
-        v_named = hax.named(v_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V)))
-        g_named = hax.named(g_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H)))
-        b_named = hax.named(beta_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H)))
-        d_out_named = hax.named(
-            d_out_arr, (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V))
-        )
-    else:
-        B, H, L, K = q_arr.shape
-        V = v_arr.shape[-1]
-        q_named = hax.named(
-            jnp.transpose(q_arr, (0, 2, 1, 3)),
-            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)),
-        )
-        k_named = hax.named(
-            jnp.transpose(k_arr, (0, 2, 1, 3)),
-            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("k_head_dim", K)),
-        )
-        v_named = hax.named(
-            jnp.transpose(v_arr, (0, 2, 1, 3)),
-            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V)),
-        )
-        g_named = hax.named(jnp.transpose(g_arr, (0, 2, 1)), (Axis("batch", B), Axis("position", L), Axis("heads", H)))
-        b_named = hax.named(
-            jnp.transpose(beta_arr, (0, 2, 1)), (Axis("batch", B), Axis("position", L), Axis("heads", H))
-        )
-        d_out_named = hax.named(
-            jnp.transpose(d_out_arr, (0, 2, 1, 3)),
-            (Axis("batch", B), Axis("position", L), Axis("heads", H), Axis("v_head_dim", V)),
-        )
+    dq, dk, dv, dg, db, dS0 = _chunk_gated_delta_rule_flash_bwd_fused(
+        q_arr,
+        k_arr,
+        v_arr,
+        g_arr,
+        beta_arr,
+        d_out_arr,
+        head_first=head_first_res,
+        lengths=lengths,
+        aux=aux,
+        initial_state_was_none=initial_state_was_none,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
 
-    # Initial state for the reference VJP (NamedArray on [B, H, K, V])
-    if initial_state_arr is None:
-        S0_arr = jnp.zeros((B, H, K, V), dtype=jnp.float32)
-    else:
-        S0_arr = initial_state_arr
-        # Pad/trim last axis not needed here; flash forward already padded V internally
-
-    S0_named = hax.named(S0_arr, (Axis("batch", B), Axis("heads", H), Axis("k_head_dim", K), Axis("v_head_dim", V)))
-
-    # Reference forward that returns only the chunk output (for VJP)
-    def _ref_f(qN, kN, vN, gN, bN, S0N):
-        yN, _ = _chunk_gated_delta_rule_reference(
-            qN,
-            kN,
-            vN,
-            gN,
-            bN,
-            chunk_size=chunk_size,
-            initial_state=S0N.array,  # IMPORTANT: pass S0 into the reference
-            output_final_state=False,
-            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-        )
-        return yN
-
-    # Rematerialized VJP
-    _, pullback = jax.vjp(_ref_f, q_named, k_named, v_named, g_named, b_named, S0_named)
-    dQ, dK, dV, dG, dB, dS0 = pullback(d_out_named)
-
-    # Pack grads back to arrays matching the *primal* argument order
-    if not head_first:
-        dq = dQ.array
-        dk = dK.array
-        dv = dV.array
-        dg = dG.array
-        db = dB.array
-        dS0_arr = dS0.array  # [B, H, K, V]
-    else:
-        dq = jnp.transpose(dQ.array, (0, 2, 1, 3))
-        dk = jnp.transpose(dK.array, (0, 2, 1, 3))
-        dv = jnp.transpose(dV.array, (0, 2, 1, 3))
-        dg = jnp.transpose(dG.array, (0, 2, 1))
-        db = jnp.transpose(dB.array, (0, 2, 1))
-        dS0_arr = dS0.array  # S0 is [B,H,K,V] regardless
-
+    # Match primal differentiable args: (q, k, v, g, beta, lengths, offsets, initial_state)
     d_lengths = None
     d_offsets = None
-    d_initial_state = dS0_arr
-
-    # Return grads for the *first 8* (differentiable) args of the primal:
-    # (q, k, v, g, beta, lengths, offsets, initial_state)
+    d_initial_state = None if initial_state_was_none else dS0
     return (dq, dk, dv, dg, db, d_lengths, d_offsets, d_initial_state)
 
 
-# Tie the custom VJP to the forward/backward defs
-_chunk_gated_delta_rule_flash_call.defvjp(
+_chunk_gated_delta_rule_flash.defvjp(
     _chunk_gated_delta_rule_flash_call_fwd,
     _chunk_gated_delta_rule_flash_call_bwd,
 )
@@ -1950,7 +2397,7 @@ def chunk_gated_delta_rule(
 ) -> tuple[NamedArray, Optional[jnp.ndarray]]:
     if use_flash:
         try:
-            out_arr, fin = _chunk_gated_delta_rule_flash_call(
+            out_arr, fin = _chunk_gated_delta_rule_flash(
                 query.array,
                 key.array,
                 value.array,

--- a/src/levanter/layers/gated_deltanet.py
+++ b/src/levanter/layers/gated_deltanet.py
@@ -4,6 +4,7 @@
 # based on:
 # - https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_next/modular_qwen3_next.py
 # - the JAX implementation by Yu Sun and Leo Lee
+# - Flash Linear Attention's Triton implementation: https://github.com/fla-org/flash-linear-attention
 
 """
 This module implements the Gated DeltaNet: https://arxiv.org/abs/2412.06464.
@@ -476,6 +477,287 @@ def _recurrent_gated_delta_rule_reference(
         return out_final, None
 
 
+def _pick_bk_tile_for_decode(dk: int) -> int:
+    # Simple heuristic; autotune later if desired.
+    if dk >= 256:
+        return 64
+    elif dk >= 128:
+        return 64
+    else:
+        return 32
+
+
+def _pick_bv_tile_for_decode(dv: int) -> int:
+    if dv >= 512:
+        return 128
+    elif dv >= 256:
+        return 64
+    else:
+        return 32
+
+
+def _pad_last_axis(arr: jnp.ndarray, new_width: int) -> jnp.ndarray:
+    """Right-pad the *last* axis to new_width."""
+    cur = arr.shape[-1]
+    if cur == new_width:
+        return arr
+    pad = new_width - cur
+    assert pad >= 0
+    pad_spec = [(0, 0)] * arr.ndim
+    pad_spec[-1] = (0, pad)
+    return jnp.pad(arr, tuple(pad_spec))
+
+
+def _pad_k_for_decode(
+    q_like_TK: jnp.ndarray,  # [..., T, K]
+    k_like_TK: jnp.ndarray,  # [..., T, K]
+    init_KV: jnp.ndarray,  # [..., K, V]
+    K_pad: int,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    q_pad = _pad_last_axis(q_like_TK, K_pad)
+    k_pad = _pad_last_axis(k_like_TK, K_pad)
+    pad_K = K_pad - init_KV.shape[-2]
+    if pad_K > 0:
+        init_pad = jnp.pad(init_KV, ((0, 0),) * (init_KV.ndim - 2) + ((0, pad_K), (0, 0)))
+    else:
+        init_pad = init_KV
+    return q_pad, k_pad, init_pad
+
+
+def _nh_to_bh(nh_i32: jnp.int32, H: int) -> tuple[jnp.int32, jnp.int32]:
+    """Map flattened nh ∈ [0, B·H) → (b, h)."""
+    b = nh_i32 // jnp.int32(H)
+    h = nh_i32 - b * jnp.int32(H)
+    return b, h
+
+
+def _in_specs_head_first(B, H, T, K_pad, BV, is_beta_headwise):
+    # Inputs (HEAD_FIRST):
+    #   q,k:  [B,H,T,K_pad]
+    #   v:    [B,H,T,V_pad]
+    #   g:    [B,H,T]
+    #   β:    [B,H,T] or [B,H,T,V_pad]
+    # State:
+    #   init, final: [B,H,K_pad,V_pad]
+    def _bh(nh, vb):
+        return _nh_to_bh(nh, H)
+
+    in_specs = (
+        pl.BlockSpec((1, 1, T, K_pad), lambda nh, vb: (*_bh(nh, vb), 0, 0)),  # q
+        pl.BlockSpec((1, 1, T, K_pad), lambda nh, vb: (*_bh(nh, vb), 0, 0)),  # k
+        pl.BlockSpec((1, 1, T, BV), lambda nh, vb: (*_bh(nh, vb), 0, vb * BV)),  # v
+        pl.BlockSpec((1, 1, T), lambda nh, vb: (*_bh(nh, vb), 0)),  # g
+        (
+            pl.BlockSpec((1, 1, T), lambda nh, vb: (*_bh(nh, vb), 0))  # β headwise
+            if is_beta_headwise
+            else pl.BlockSpec((1, 1, T, BV), lambda nh, vb: (*_bh(nh, vb), 0, vb * BV))
+        ),  # β per‑V
+        pl.BlockSpec((1, 1, K_pad, BV), lambda nh, vb: (*_bh(nh, vb), 0, vb * BV)),  # init
+        pl.BlockSpec((1,), lambda nh, vb: (nh,)),  # lengths [NH]
+    )
+    # Outputs:
+    #   out:   [NH, T, V_pad]   (3‑D)
+    #   final: [B,H,K_pad,V_pad]
+    out_specs = (
+        pl.BlockSpec((1, T, BV), lambda nh, vb: (nh, 0, vb * BV)),  # out (NH-major)
+        pl.BlockSpec((1, 1, K_pad, BV), lambda nh, vb: (*_bh(nh, vb), 0, vb * BV)),  # final
+    )
+    return in_specs, out_specs
+
+
+def _in_specs_bth(B, H, T, K_pad, BV, is_beta_headwise):
+    # Inputs (BTH):
+    #   q,k:  [B, T, H, K_pad]
+    #   v:    [B, T, H, V_pad]
+    #   g:    [B, T, H]
+    #   β:    [B, T, H] (headwise) or [B, T, H, V_pad] (per-V)
+    # State:
+    #   init, final: [B, H, K_pad, V_pad]
+
+    def _bth(nh, vb):
+        b, h = _nh_to_bh(nh, H)
+        return (b, 0, h)  # (B, T_start, H)
+
+    in_specs = (
+        # q, k: 4-D tiles (1, T, 1, K_pad)
+        pl.BlockSpec((1, T, 1, K_pad), lambda nh, vb: (*_bth(nh, vb), 0)),
+        pl.BlockSpec((1, T, 1, K_pad), lambda nh, vb: (*_bth(nh, vb), 0)),
+        # v: 4-D tile (1, T, 1, BV)
+        pl.BlockSpec((1, T, 1, BV), lambda nh, vb: (*_bth(nh, vb), vb * BV)),
+        # g: 3-D tile (1, T, 1)  → must return exactly 3 indices (b, 0, h)
+        pl.BlockSpec((1, T, 1), lambda nh, vb: _bth(nh, vb)),
+        # β: headwise uses 3-D (1, T, 1); per-V uses 4-D (1, T, 1, BV)
+        (
+            pl.BlockSpec((1, T, 1), lambda nh, vb: _bth(nh, vb))  # headwise β
+            if is_beta_headwise
+            else pl.BlockSpec((1, T, 1, BV), lambda nh, vb: (*_bth(nh, vb), vb * BV))
+        ),  # per-V β
+        # init state: 4-D (1, 1, K_pad, BV) into [B,H,K_pad,V_pad]
+        pl.BlockSpec((1, 1, K_pad, BV), lambda nh, vb: (_nh_to_bh(nh, H)[0], _nh_to_bh(nh, H)[1], 0, vb * BV)),
+        # lengths: 1-D (1,) over NH
+        pl.BlockSpec((1,), lambda nh, vb: (nh,)),
+    )
+
+    out_specs = (
+        # out: NH-major 3-D (1, T, BV)
+        pl.BlockSpec((1, T, BV), lambda nh, vb: (nh, 0, vb * BV)),
+        # final state: 4-D (1, 1, K_pad, BV) into [B,H,K_pad,V_pad]
+        pl.BlockSpec((1, 1, K_pad, BV), lambda nh, vb: (_nh_to_bh(nh, H)[0], _nh_to_bh(nh, H)[1], 0, vb * BV)),
+    )
+    return in_specs, out_specs
+
+
+def _gdn_recurrent_fwd_kernel_tiled_2d(
+    q_ref,
+    k_ref,
+    v_ref,
+    g_ref,
+    beta_ref,
+    init_ref,
+    lengths_ref,
+    out_ref,
+    final_ref,
+    *,
+    T,
+    K_pad,
+    BK,
+    BV,
+    use_qk_l2norm,
+    has_initial_state,
+    is_beta_headwise,
+    scale,
+    head_first_layout: bool,  # NEW: tells us how to squeeze 4-D tiles
+):
+    # ---- Local (tile) views; squeeze the 1-sized dims to get 2-D/1-D arrays ----
+    if head_first_layout:
+        # q,k: [1,1,T,K] → (T,K); v: [1,1,T,BV] → (T,BV); g: [1,1,T] → (T,)
+        q_view = q_ref[dslice(0, 1), dslice(0, 1), dslice(0, T), dslice(0, K_pad)][0, 0]
+        k_view = k_ref[dslice(0, 1), dslice(0, 1), dslice(0, T), dslice(0, K_pad)][0, 0]
+        v_view = v_ref[dslice(0, 1), dslice(0, 1), dslice(0, T), dslice(0, BV)][0, 0]
+        g_view = g_ref[dslice(0, 1), dslice(0, 1), dslice(0, T)][0, 0]
+        if is_beta_headwise:
+            beta_h = beta_ref[dslice(0, 1), dslice(0, 1), dslice(0, T)][0, 0]  # (T,)
+        else:
+            beta_h = beta_ref[dslice(0, 1), dslice(0, 1), dslice(0, T), dslice(0, BV)][0, 0]  # (T,BV)
+
+        # State tiles: [1,1,K,BV] → (K,BV)
+        def _read_state(k0, n):
+            return final_ref[dslice(0, 1), dslice(0, 1), dslice(k0, n), dslice(0, BV)][0, 0]
+
+        def _write_state(k0, block):
+            final_ref[dslice(0, 1), dslice(0, 1), dslice(k0, block.shape[0]), dslice(0, BV)] = block[None, None, :, :]
+
+        def _read_init(k0, n):
+            return init_ref[dslice(0, 1), dslice(0, 1), dslice(k0, n), dslice(0, BV)][0, 0]
+
+    else:
+        # q,k: [1,T,1,K] → (T,K); v: [1,T,1,BV] → (T,BV); g: [1,T,1] → (T,)
+        q_view = q_ref[dslice(0, 1), dslice(0, T), dslice(0, 1), dslice(0, K_pad)][0, :, 0, :]
+        k_view = k_ref[dslice(0, 1), dslice(0, T), dslice(0, 1), dslice(0, K_pad)][0, :, 0, :]
+        v_view = v_ref[dslice(0, 1), dslice(0, T), dslice(0, 1), dslice(0, BV)][0, :, 0, :]
+        g_view = g_ref[dslice(0, 1), dslice(0, T), dslice(0, 1)][0, :, 0]
+        if is_beta_headwise:
+            beta_h = beta_ref[dslice(0, 1), dslice(0, T), dslice(0, 1)][0, :, 0]  # (T,)
+        else:
+            beta_h = beta_ref[dslice(0, 1), dslice(0, T), dslice(0, 1), dslice(0, BV)][0, :, 0, :]  # (T,BV)
+
+        # State tiles: [1,1,K,BV] → (K,BV)
+        def _read_state(k0, n):
+            return final_ref[dslice(0, 1), dslice(0, 1), dslice(k0, n), dslice(0, BV)][0, 0]
+
+        def _write_state(k0, block):
+            final_ref[dslice(0, 1), dslice(0, 1), dslice(k0, block.shape[0]), dslice(0, BV)] = block[None, None, :, :]
+
+        def _read_init(k0, n):
+            return init_ref[dslice(0, 1), dslice(0, 1), dslice(k0, n), dslice(0, BV)][0, 0]
+
+    # ---- Initialize per-tile state buffer from init_ref once ----
+    n_ktiles = K_pad // BK
+
+    def _copy_body(kb, _):
+        k0 = kb * BK
+        S_blk = _read_init(k0, BK).astype(jnp.float32) if has_initial_state else jnp.zeros((BK, BV), dtype=jnp.float32)
+        _write_state(k0, S_blk.astype(final_ref.dtype))
+        return ()
+
+    _ = lax.fori_loop(0, n_ktiles, _copy_body, ())
+
+    L_i32 = lengths_ref[dslice(0, 1)][0].astype(jnp.int32)
+    T_i32 = jnp.int32(T)
+    scale32 = jnp.asarray(scale, dtype=jnp.float32)
+
+    out_tile = jnp.zeros((T, BV), dtype=out_ref.dtype)
+
+    def time_step(t, out_cur):
+        do_step = t < L_i32
+
+        q_t = q_view[t].astype(jnp.float32)  # (K_pad,)
+        k_t = k_view[t].astype(jnp.float32)  # (K_pad,)
+        v_t = v_view[t].astype(jnp.float32)  # (BV,)
+        g_t = g_view[t].astype(jnp.float32)
+        alpha = jnp.exp(g_t)
+
+        if use_qk_l2norm:
+            q_norm = jnp.sqrt(jnp.sum(q_t * q_t) + 1e-6)
+            k_norm = jnp.sqrt(jnp.sum(k_t * k_t) + 1e-6)
+            q_t = q_t / jnp.where(q_norm > 0.0, q_norm, 1.0)
+            k_t = k_t / jnp.where(k_norm > 0.0, k_norm, 1.0)
+        q_t = q_t * scale32
+
+        def _do_step(_):
+            # ---- Pass 1: accumulate kv, y_alpha, kq (no writes) ----
+            kv = jnp.zeros((BV,), dtype=jnp.float32)
+            y_alpha = jnp.zeros((BV,), dtype=jnp.float32)
+            kq = jnp.array(0.0, dtype=jnp.float32)
+
+            def pass1_body(kb, acc):
+                kv_acc, yA_acc, kq_acc = acc
+                k0 = kb * BK
+                k_chunk = lax.dynamic_slice_in_dim(k_t, start_index=k0, slice_size=BK, axis=0)
+                q_chunk = lax.dynamic_slice_in_dim(q_t, start_index=k0, slice_size=BK, axis=0)
+                S_blk = _read_state(k0, BK).astype(jnp.float32)
+
+                kv_acc = kv_acc + jnp.sum(S_blk * (alpha * k_chunk)[:, None], axis=0)
+                yA_acc = yA_acc + jnp.sum(S_blk * (alpha * q_chunk)[:, None], axis=0)
+                kq_acc = kq_acc + jnp.sum(k_chunk * q_chunk)
+                return (kv_acc, yA_acc, kq_acc)
+
+            kv, y_alpha, kq = lax.fori_loop(0, n_ktiles, pass1_body, (kv, y_alpha, kq))
+
+            # δ = (v - kv) * β
+            if is_beta_headwise:
+                delta = (v_t - kv) * beta_h[t].astype(jnp.float32)
+            else:
+                delta = (v_t - kv) * beta_h[t].astype(jnp.float32)
+
+            # y = y_alpha + δ * (k^T q)
+            y_t = (y_alpha + delta * kq).astype(out_ref.dtype)
+
+            # ---- Pass 2: S_new = α S_blk + k⊗δ (single write) ----
+            def pass2_body(kb, _):
+                k0 = kb * BK
+                k_chunk = lax.dynamic_slice_in_dim(k_t, start_index=k0, slice_size=BK, axis=0)
+                S_blk = _read_state(k0, BK).astype(jnp.float32)
+                S_new = S_blk * alpha + k_chunk[:, None] * delta[None, :]
+                _write_state(k0, S_new.astype(final_ref.dtype))
+                return ()
+
+            _ = lax.fori_loop(0, n_ktiles, pass2_body, ())
+            return y_t
+
+        def _skip_step(_):
+            return jnp.zeros((BV,), dtype=out_ref.dtype)
+
+        y_t = lax.cond(do_step, _do_step, _skip_step, operand=None)
+        out_next = out_cur.at[t].set(y_t)
+        return out_next
+
+    out_tile = lax.fori_loop(0, T_i32, time_step, out_tile)
+
+    # Local writes (out is NH-major 3‑D)
+    out_ref[dslice(0, 1), dslice(0, T), dslice(0, BV)] = out_tile[None, :, :]
+
+
 def _recurrent_gated_delta_rule_flash(
     query: NamedArray,
     key: NamedArray,
@@ -483,9 +765,11 @@ def _recurrent_gated_delta_rule_flash(
     g: NamedArray,
     beta: NamedArray,
     *,
-    initial_state: Optional[jnp.ndarray] = None,
+    initial_state: Optional[jnp.ndarray] = None,  # [B,H,dk,dv]
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = True,
+    head_first: bool = False,  # True: inputs are [B,H,T,*]; False: [B,T,H,*]
+    lengths: Optional[jnp.ndarray] = None,  # [B*H] or [B,H]
 ) -> Tuple[NamedArray, Optional[jnp.ndarray]]:
     Batch = query.resolve_axis("batch")
     Pos = query.resolve_axis("position")
@@ -493,157 +777,148 @@ def _recurrent_gated_delta_rule_flash(
     Dk = query.resolve_axis("k_head_dim")
     Dv = value.resolve_axis("v_head_dim")
 
-    q = query.astype(jnp.float32)
-    k = key.astype(jnp.float32)
-    v = value.astype(jnp.float32)
-    gg = g.astype(jnp.float32)
-    b = beta.astype(jnp.float32)
-
-    q_arr = hax.rearrange(q, (Batch, Heads, Pos, Dk)).array
-    k_arr = hax.rearrange(k, (Batch, Heads, Pos, Dk)).array
-    v_arr = hax.rearrange(v, (Batch, Heads, Pos, Dv)).array
-    g_arr = hax.rearrange(gg, (Batch, Heads, Pos)).array
-
-    beta_axis_names = tuple(ax.name for ax in beta.axes)
-    if Dv.name in beta_axis_names:
-        beta_arr = hax.rearrange(b, (Batch, Heads, Pos, Dv)).array
-        is_beta_headwise = False
-    else:
-        beta_arr = hax.rearrange(b, (Batch, Heads, Pos)).array
-        is_beta_headwise = True
-
-    B_, H_, T_, K_ = q_arr.shape
-    V_ = v_arr.shape[-1]
+    B_, T_, H_, K_ = Batch.size, Pos.size, Heads.size, Dk.size
+    V_ = Dv.size
     NH = B_ * H_
 
-    q_flat = q_arr.reshape(NH, T_, K_)
-    k_flat = k_arr.reshape(NH, T_, K_)
-    v_flat = v_arr.reshape(NH, T_, V_)
-    g_flat = g_arr.reshape(NH, T_)
-    if is_beta_headwise:
-        beta_flat = beta_arr.reshape(NH, T_)
-    else:
-        beta_flat = beta_arr.reshape(NH, T_, V_)
+    # Ensure arrays match the declared layout (no-op if already matching)
+    def _ensure_layout(x_named: NamedArray, layout: tuple[str, ...]) -> jnp.ndarray:
+        have = tuple(ax.name for ax in x_named.axes)
+        if have == layout:
+            return x_named.array
+        return hax.rearrange(x_named, layout).array
 
-    if initial_state is None:
-        init_state = jnp.zeros((NH, K_, V_), dtype=jnp.float32)
-    else:
-        init_state = initial_state.astype(jnp.float32).reshape(NH, K_, V_)
-
-    def kernel(
-        q_ref,
-        k_ref,
-        v_ref,
-        g_ref,
-        beta_ref,
-        init_ref,
-        out_ref,
-        final_ref,
-        *,
-        T,
-        K,
-        V,
-        use_qk_l2norm,
-        store_final_state,
-        has_initial_state,
-        is_beta_headwise,
-        scale,
-    ):
-        head = pl.program_id(0)
-        q_view = q_ref[dslice(head, 1), dslice(0, T), dslice(0, K)][0]
-        k_view = k_ref[dslice(head, 1), dslice(0, T), dslice(0, K)][0]
-        v_view = v_ref[dslice(head, 1), dslice(0, T), dslice(0, V)][0]
-        g_view = g_ref[dslice(head, 1), dslice(0, T)][0]
-        beta_view = (
-            beta_ref[dslice(head, 1), dslice(0, T)][0]
-            if is_beta_headwise
-            else beta_ref[dslice(head, 1), dslice(0, T), dslice(0, V)][0]
-        )
-        if has_initial_state:
-            state = init_ref[dslice(head, 1), dslice(0, K), dslice(0, V)][0].astype(jnp.float32)
+    if head_first:
+        q_arr = _ensure_layout(query.astype(jnp.float32), (Batch.name, Heads.name, Pos.name, Dk.name))  # [B,H,T,K]
+        k_arr = _ensure_layout(key.astype(jnp.float32), (Batch.name, Heads.name, Pos.name, Dk.name))
+        v_arr = _ensure_layout(value.astype(jnp.float32), (Batch.name, Heads.name, Pos.name, Dv.name))
+        g_arr = _ensure_layout(g.astype(jnp.float32), (Batch.name, Heads.name, Pos.name))
+        beta_axis_names = tuple(ax.name for ax in beta.axes)
+        is_beta_headwise = Dv.name not in beta_axis_names
+        if is_beta_headwise:
+            beta_arr = _ensure_layout(beta.astype(jnp.float32), (Batch.name, Heads.name, Pos.name))  # [B,H,T]
         else:
-            state = jnp.zeros((K, V), dtype=jnp.float32)
+            beta_arr = _ensure_layout(
+                beta.astype(jnp.float32), (Batch.name, Heads.name, Pos.name, Dv.name)
+            )  # [B,H,T,V]
+    else:
+        q_arr = _ensure_layout(query.astype(jnp.float32), (Batch.name, Pos.name, Heads.name, Dk.name))  # [B,T,H,K]
+        k_arr = _ensure_layout(key.astype(jnp.float32), (Batch.name, Pos.name, Heads.name, Dk.name))
+        v_arr = _ensure_layout(value.astype(jnp.float32), (Batch.name, Pos.name, Heads.name, Dv.name))
+        g_arr = _ensure_layout(g.astype(jnp.float32), (Batch.name, Pos.name, Heads.name))
+        beta_axis_names = tuple(ax.name for ax in beta.axes)
+        is_beta_headwise = Dv.name not in beta_axis_names
+        if is_beta_headwise:
+            beta_arr = _ensure_layout(beta.astype(jnp.float32), (Batch.name, Pos.name, Heads.name))  # [B,T,H]
+        else:
+            beta_arr = _ensure_layout(
+                beta.astype(jnp.float32), (Batch.name, Pos.name, Heads.name, Dv.name)
+            )  # [B,T,H,V]
 
-        scale32 = jnp.asarray(scale, dtype=jnp.float32)
+    # Initial state: [B,H,K,V]
+    if initial_state is None:
+        init_arr = jnp.zeros((B_, H_, K_, V_), dtype=jnp.float32)
+        has_initial = False
+    else:
+        init_in = initial_state.astype(jnp.float32)
+        if init_in.shape == (B_, H_, K_, V_):
+            init_arr = init_in
+        elif init_in.ndim == 3 and init_in.shape[0] == NH:
+            init_arr = init_in.reshape(B_, H_, K_, V_)
+        else:
+            init_arr = hax.rearrange(
+                hax.named(init_in, (Batch, Heads, Dk, Dv)),
+                (Batch.name, Heads.name, Dk.name, Dv.name),
+            ).array
+        has_initial = True
 
-        out_tile = jnp.zeros((T, V), dtype=out_ref.dtype)
-        for t in range(T):
-            q_t = q_view[t].astype(jnp.float32)
-            k_t = k_view[t].astype(jnp.float32)
-            if use_qk_l2norm:
-                q_t = q_t / jnp.sqrt(jnp.sum(q_t * q_t) + 1e-6)
-                k_t = k_t / jnp.sqrt(jnp.sum(k_t * k_t) + 1e-6)
-            q_t = q_t * scale32
-            v_t = v_view[t].astype(jnp.float32)
-            g_t = g_view[t].astype(jnp.float32)
-            state = state * jnp.exp(g_t)
+    # Varlen
+    if lengths is None:
+        lengths_flat = jnp.full((NH,), T_, dtype=jnp.int32)
+    else:
+        lf = lengths
+        if lf.ndim == 2 and lf.shape == (B_, H_):
+            lf = lf.reshape(NH)
+        lengths_flat = lf.astype(jnp.int32)
 
-            kv = jnp.sum(state * k_t[:, None], axis=0)
-            if is_beta_headwise:
-                beta_t = beta_view[t].astype(jnp.float32)
-                delta = (v_t - kv) * beta_t
-            else:
-                beta_t = beta_view[t].astype(jnp.float32)
-                delta = (v_t - kv) * beta_t
-            state = state + k_t[:, None] * delta[None, :]
+    # 2D tiling & padding
+    BK = _pick_bk_tile_for_decode(Dk.size)
+    BV = _pick_bv_tile_for_decode(Dv.size)
+    K_pad = int(((K_ + BK - 1) // BK) * BK)
+    V_pad = int(((V_ + BV - 1) // BV) * BV)
 
-            out_tile = out_tile.at[t].set(jnp.sum(state * q_t[:, None], axis=0).astype(out_ref.dtype))
+    if head_first:
+        # Pad K with BH→NH reshape and back; pad V in place
+        q_pad, k_pad, init_kpad = _pad_k_for_decode(
+            q_arr.reshape(B_ * H_, T_, K_),
+            k_arr.reshape(B_ * H_, T_, K_),
+            init_arr.reshape(B_ * H_, K_, V_),
+            K_pad,
+        )
+        q_pad = q_pad.reshape(B_, H_, T_, K_pad)
+        k_pad = k_pad.reshape(B_, H_, T_, K_pad)
+        init_kpad = init_kpad.reshape(B_, H_, K_pad, V_)
+        v_pad = _pad_last_axis(v_arr, V_pad)  # [B,H,T,V_pad]
+        beta_pad = beta_arr if is_beta_headwise else _pad_last_axis(beta_arr, V_pad)
+    else:
+        q_pad, k_pad, init_kpad = _pad_k_for_decode(
+            q_arr.reshape(B_ * H_, T_, K_),
+            k_arr.reshape(B_ * H_, T_, K_),
+            init_arr.reshape(B_ * H_, K_, V_),
+            K_pad,
+        )
+        q_pad = q_pad.reshape(B_, T_, H_, K_pad)
+        k_pad = k_pad.reshape(B_, T_, H_, K_pad)
+        init_kpad = init_kpad.reshape(B_, H_, K_pad, V_)
+        v_pad = _pad_last_axis(v_arr, V_pad)  # [B,T,H,V_pad]
+        beta_pad = beta_arr if is_beta_headwise else _pad_last_axis(beta_arr, V_pad)
 
-        out_ref[dslice(head, 1), dslice(0, T), dslice(0, V)] = out_tile[None, :, :]
-
-        if store_final_state:
-            final_ref[dslice(head, 1), dslice(0, K), dslice(0, V)] = state.astype(final_ref.dtype)[None, :, :]
-
-    out_struct = jax.ShapeDtypeStruct((NH, T_, V_), v_flat.dtype)
-    final_struct = jax.ShapeDtypeStruct((NH, K_, V_), jnp.float32)
+    # Pallas shapes
+    out_struct = jax.ShapeDtypeStruct((NH, T_, V_pad), value.dtype)  # NH-major for output
+    final_struct = jax.ShapeDtypeStruct((B_, H_, K_pad, V_pad), jnp.float32)
 
     kernel_partial = functools.partial(
-        kernel,
+        _gdn_recurrent_fwd_kernel_tiled_2d,
         T=T_,
-        K=K_,
-        V=V_,
+        K_pad=K_pad,
+        BK=int(BK),
+        BV=int(BV),
         use_qk_l2norm=use_qk_l2norm_in_kernel,
-        store_final_state=output_final_state,
-        has_initial_state=initial_state is not None,
+        has_initial_state=has_initial,
         is_beta_headwise=is_beta_headwise,
         scale=Dk.size**-0.5,
+        head_first_layout=head_first,  # pass layout flag to kernel
     )
 
-    beta_spec: pl.BlockSpec
-    if is_beta_headwise:
-        beta_spec = pl.BlockSpec((1, T_), lambda bid_nh: (bid_nh, 0))
-    else:
-        beta_spec = pl.BlockSpec((1, T_, V_), lambda bid_nh: (bid_nh, 0, 0))
+    n_vtiles = V_pad // BV
+    grid = (NH, n_vtiles)
 
-    result = pl.pallas_call(
+    in_specs, out_specs = (
+        _in_specs_head_first(B_, H_, T_, K_pad, BV, is_beta_headwise)
+        if head_first
+        else _in_specs_bth(B_, H_, T_, K_pad, BV, is_beta_headwise)
+    )
+
+    out_pad, final_pad = pl.pallas_call(
         kernel_partial,
         out_shape=(out_struct, final_struct),
-        grid=(NH,),
-        in_specs=(
-            pl.BlockSpec((1, T_, K_), lambda bid_nh: (bid_nh, 0, 0)),
-            pl.BlockSpec((1, T_, K_), lambda bid_nh: (bid_nh, 0, 0)),
-            pl.BlockSpec((1, T_, V_), lambda bid_nh: (bid_nh, 0, 0)),
-            pl.BlockSpec((1, T_), lambda bid_nh: (bid_nh, 0)),
-            beta_spec,
-            pl.BlockSpec((1, K_, V_), lambda bid_nh: (bid_nh, 0, 0)),
-        ),
-        out_specs=(
-            pl.BlockSpec((1, T_, V_), lambda bid_nh: (bid_nh, 0, 0)),
-            pl.BlockSpec((1, K_, V_), lambda bid_nh: (bid_nh, 0, 0)),
-        ),
+        grid=grid,
+        in_specs=in_specs,
+        out_specs=out_specs,
         interpret=_should_interpret_pallas(),
-    )(q_flat, k_flat, v_flat, g_flat, beta_flat, init_state)
+    )(q_pad, k_pad, v_pad, g_arr, beta_pad, init_kpad, lengths_flat)
 
-    out_flat, final_flat = result
-    out_arr = out_flat.reshape(B_, H_, T_, V_)
-    out_named = hax.named(out_arr, (Batch, Heads, Pos, Dv))
-    out_final = hax.rearrange(out_named, (Batch, Pos, Heads, Dv))
-
+    # Trim and wrap
+    out_trim = out_pad[:, :, :V_]
     if output_final_state:
-        final_arr = final_flat.reshape(B_, H_, K_, V_)
-        return out_final, final_arr
-    else:
-        return out_final, None
+        final_trim = final_pad[:, :, :K_, :V_]  # [B,H,K,V]
+
+    out_bhTv = out_trim.reshape(B_, H_, T_, V_)
+    out_named = hax.named(out_bhTv, (Batch, Heads, Pos, Dv))
+    out_final_named = hax.rearrange(out_named, (Batch, Pos, Heads, Dv))
+
+    final_ret = None if not output_final_state else final_trim.reshape(B_, H_, Dk.size, Dv.size)
+    return out_final_named, final_ret
 
 
 def recurrent_gated_delta_rule(
@@ -669,6 +944,9 @@ def recurrent_gated_delta_rule(
                 initial_state=initial_state,
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                # optional toggles:
+                head_first=False,
+                lengths=None,
             )
         except Exception:
             if use_flash:

--- a/tests/test_gdn_kernels.py
+++ b/tests/test_gdn_kernels.py
@@ -11,7 +11,13 @@ import haliax.nn as hnn
 from haliax import Axis
 import pytest
 
-from levanter.layers.gated_deltanet import FusedRMSNormGated, chunk_gated_delta_rule, recurrent_gated_delta_rule
+from levanter.layers.gated_deltanet import (
+    FusedRMSNormGated,
+    chunk_gated_delta_rule,
+    recurrent_gated_delta_rule,
+    _rmsnorm_gated_flash,
+    _rmsnorm_gated_reference,
+)
 from tests.test_utils import skip_if_no_torch
 
 jax.config.update("jax_default_matmul_precision", "float32")
@@ -70,6 +76,76 @@ def test_fused_rms_norm_gated_matches_reference():
 
     np.testing.assert_allclose(y_flash.array, y_ref.array, rtol=1e-6, atol=1e-6)
     np.testing.assert_allclose(y_flash.array, expected.array, rtol=1e-6, atol=1e-6)
+
+
+def test_fused_rms_norm_gated_backward_matches_reference():
+    """Gradient parity for fused RMSNorm + SiLU gate against the reference JAX path.
+
+    Compares grads w.r.t. inputs (x, gate) and the weight parameter.
+    """
+    key = jax.random.PRNGKey(123)
+    kx, kg, kw = jax.random.split(key, 3)
+
+    N, D = 7, 9
+    x = jax.random.normal(kx, (N, D), dtype=jnp.float32)
+    gate = jax.random.normal(kg, (N, D), dtype=jnp.float32)
+    weight = jax.random.normal(kw, (D,), dtype=jnp.float32)
+    eps = 1e-6
+
+    def loss_flash(x_arr, g_arr, w_arr):
+        y = _rmsnorm_gated_flash(x_arr, g_arr, w_arr, eps)
+        return jnp.sum(y)
+
+    def loss_ref(x_arr, g_arr, w_arr):
+        y = _rmsnorm_gated_reference(x_arr, g_arr, w_arr, eps)
+        return jnp.sum(y)
+
+    gx_f, gg_f, gw_f = jax.grad(loss_flash, argnums=(0, 1, 2))(x, gate, weight)
+    gx_r, gg_r, gw_r = jax.grad(loss_ref, argnums=(0, 1, 2))(x, gate, weight)
+
+    np.testing.assert_allclose(np.array(gx_f), np.array(gx_r), rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(np.array(gg_f), np.array(gg_r), rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(np.array(gw_f), np.array(gw_r), rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_flash_chunk_backward_chunk_size_invariance_kernel_level(use_flash: bool):
+    """Kernel-level: gradients should be invariant to chunk_size (flash path).
+
+    We compare grads wrt q,k,v,g,beta for two chunk sizes.
+    """
+    key = jax.random.PRNGKey(0)
+    B, H, L, dk, dv = 1, 2, 27, 8, 8
+    q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
+
+    def loss_with_chunk(q_arr, k_arr, v_arr, g_arr, b_arr, chunk_size):
+        qn = hax.named(q_arr, q.axes)
+        kn = hax.named(k_arr, k.axes)
+        vn = hax.named(v_arr, v.axes)
+        gn = hax.named(g_arr, g.axes)
+        bn = hax.named(b_arr, beta.axes)
+        out, _ = chunk_gated_delta_rule(
+            qn,
+            kn,
+            vn,
+            gn,
+            bn,
+            chunk_size=chunk_size,
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            use_flash=use_flash,
+        )
+        return jnp.sum(out.array)
+
+    grads8 = jax.grad(lambda qa, ka, va, ga, ba: loss_with_chunk(qa, ka, va, ga, ba, 8), argnums=(0, 1, 2, 3, 4))(
+        q.array, k.array, v.array, g.array, beta.array
+    )
+    grads32 = jax.grad(lambda qa, ka, va, ga, ba: loss_with_chunk(qa, ka, va, ga, ba, 32), argnums=(0, 1, 2, 3, 4))(
+        q.array, k.array, v.array, g.array, beta.array
+    )
+
+    for g8, g32 in zip(grads8, grads32):
+        np.testing.assert_allclose(np.array(g8), np.array(g32), rtol=3e-5, atol=3e-6)
 
 
 @pytest.mark.parametrize("use_flash", [True, False])

--- a/tests/test_gdn_kernels.py
+++ b/tests/test_gdn_kernels.py
@@ -837,7 +837,6 @@ def test_recurrent_backward_matches_hf():
 
     tq, tk, tv, tg, tb, tS0 = [x.grad.detach().cpu().numpy() for x in (q_t, k_t, v_t, g_t, b_t, S0_t)]
 
-    # Compare
     np.testing.assert_allclose(jq, tq, rtol=1e-4, atol=5e-6)
     np.testing.assert_allclose(jk, tk, rtol=1e-4, atol=5e-6)
     np.testing.assert_allclose(jv, tv, rtol=1e-4, atol=5e-6)
@@ -918,7 +917,6 @@ def test_chunk_backward_matches_hf(use_flash: bool):
 
     tq, tk, tv, tg, tb, tS0 = [x.grad.detach().cpu().numpy() for x in (q_t, k_t, v_t, g_t, b_t, S0_t)]
 
-    # Compare
     np.testing.assert_allclose(jq, tq, rtol=1e-4, atol=5e-6)
     np.testing.assert_allclose(jk, tk, rtol=1e-4, atol=5e-6)
     np.testing.assert_allclose(jv, tv, rtol=1e-4, atol=5e-6)

--- a/tests/test_gdn_kernels.py
+++ b/tests/test_gdn_kernels.py
@@ -129,38 +129,74 @@ def test_recurrent_perfect_fit_on_current_key_when_alpha1_beta1_and_L2norm(use_f
         np.testing.assert_allclose(kv, v_arr, rtol=1e-4, atol=1e-4)
 
 
+@pytest.mark.parametrize("use_flash", [True, False])
 @pytest.mark.parametrize("chunk_size", [1, 2, 7, 16, 32, 64])
-def test_chunk_equals_recurrent_for_random_inputs(chunk_size):
+def test_chunk_equals_recurrent_for_random_inputs(chunk_size, use_flash):
     """Chunkwise kernel must match recurrent kernel for many chunk sizes (including 1)."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 2, 3, 57, 8, 8
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
     out_chunk, S_chunk = chunk_gated_delta_rule(
-        q, k, v, g, beta, chunk_size=chunk_size, output_final_state=True, use_qk_l2norm_in_kernel=True
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=use_flash,
     )
     out_recur, S_recur = recurrent_gated_delta_rule(
-        q, k, v, g, beta, initial_state=None, output_final_state=True, use_qk_l2norm_in_kernel=True
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=None,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=use_flash,
     )
 
     np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=1e-4, atol=1e-4)
     np.testing.assert_allclose(S_chunk, S_recur, rtol=1e-4, atol=1e-4)
 
 
-def test_chunk_nondivisible_padding_matches_recurrent_jax_only():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_nondivisible_padding_matches_recurrent_jax_only(use_flash: bool):
     """When L % chunk_size != 0, padding path should still match the recurrent kernel (JAX-only)."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 2, 4, 61, 8, 16
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
     out_chunk, _ = chunk_gated_delta_rule(
-        q, k, v, g, beta, chunk_size=32, output_final_state=False, use_qk_l2norm_in_kernel=True
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=use_flash,
     )
-    out_recur, _ = recurrent_gated_delta_rule(q, k, v, g, beta, output_final_state=False, use_qk_l2norm_in_kernel=True)
+    out_recur, _ = recurrent_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=use_flash,
+    )
     np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=1e-4, atol=1e-4)
 
 
-def test_chunk_continuation_two_pass_equals_one_pass():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_continuation_two_pass_equals_one_pass(use_flash: bool):
     """
     Run prefix → get S_mid → run suffix with initial_state, and match the one-pass result.
     Pure JAX: validates the initial_state continuation semantics of the chunk kernel.
@@ -172,7 +208,16 @@ def test_chunk_continuation_two_pass_equals_one_pass():
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
     # One pass over the full sequence
-    out_full, S_full = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=chunk_size, output_final_state=True)
+    out_full, S_full = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        output_final_state=True,
+        use_flash=use_flash,
+    )
 
     # Two-pass: prefix then suffix with initial_state
     q_pre, q_suf = q["position", hax.ds(0, split)], q["position", hax.ds(split, Axis("pos2", L - split))]
@@ -182,10 +227,25 @@ def test_chunk_continuation_two_pass_equals_one_pass():
     b_pre, b_suf = beta["position", hax.ds(0, split)], beta["position", hax.ds(split, Axis("pos2", L - split))]
 
     out_pre, S_mid = chunk_gated_delta_rule(
-        q_pre, k_pre, v_pre, g_pre, b_pre, chunk_size=chunk_size, output_final_state=True
+        q_pre,
+        k_pre,
+        v_pre,
+        g_pre,
+        b_pre,
+        chunk_size=chunk_size,
+        output_final_state=True,
+        use_flash=use_flash,
     )
     out_suf, S_end = chunk_gated_delta_rule(
-        q_suf, k_suf, v_suf, g_suf, b_suf, chunk_size=chunk_size, initial_state=S_mid, output_final_state=True
+        q_suf,
+        k_suf,
+        v_suf,
+        g_suf,
+        b_suf,
+        chunk_size=chunk_size,
+        initial_state=S_mid,
+        output_final_state=True,
+        use_flash=use_flash,
     )
 
     # Compare outputs on the suffix region and final states
@@ -194,21 +254,38 @@ def test_chunk_continuation_two_pass_equals_one_pass():
     np.testing.assert_allclose(S_end, S_full, rtol=1e-4, atol=1e-4)
 
 
-def test_chunk_size_one_degenerates_to_recurrent_without_l2norm():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_size_one_degenerates_to_recurrent_without_l2norm(use_flash: bool):
     """Degeneracy should also hold even when L2 norm is disabled."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 2, 2, 29, 8, 8
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
     out_chunk, _ = chunk_gated_delta_rule(
-        q, k, v, g, beta, chunk_size=1, output_final_state=False, use_qk_l2norm_in_kernel=False
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=1,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=False,
+        use_flash=use_flash,
     )
     out_recur, _ = recurrent_gated_delta_rule(
-        q, k, v, g, beta, output_final_state=False, use_qk_l2norm_in_kernel=False
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=False,
+        use_flash=use_flash,
     )
     np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=3e-4, atol=1e-4)
 
 
-def test_extreme_gates_numerical_stability_jax_only():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_extreme_gates_numerical_stability_jax_only(use_flash: bool):
     """Outputs should be finite when α ≈ 0 (very negative g) and β near 0 or near 1."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 1, 2, 37, 16, 8
@@ -220,14 +297,32 @@ def test_extreme_gates_numerical_stability_jax_only():
     beta_big = hax.named(jnp.full((B, L, H), 1.0 - 1e-6, dtype=jnp.float32), ("batch", "position", "heads"))
 
     for beta in [beta_small, beta_big]:
-        out_chunk, _ = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=32, output_final_state=False)
+        out_chunk, _ = chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            chunk_size=32,
+            output_final_state=False,
+            use_flash=use_flash,
+        )
         assert np.isfinite(np.array(out_chunk.array)).all()
 
-        out_recur, _ = recurrent_gated_delta_rule(q, k, v, g, beta, output_final_state=False)
+        out_recur, _ = recurrent_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            output_final_state=False,
+            use_flash=use_flash,
+        )
         assert np.isfinite(np.array(out_recur.array)).all()
 
 
-def test_gradients_exist_small_kernel_graph():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_gradients_exist_small_kernel_graph(use_flash: bool):
     """Smoke test: both kernels are differentiable w.r.t. inputs (no NaNs in grads)."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 1, 1, 7, 4, 4
@@ -236,17 +331,38 @@ def test_gradients_exist_small_kernel_graph():
     # grad wrt q only (keep the surface small)
     def loss_chunk(q_arr):
         qn = hax.named(q_arr, q.axes)
-        out, _ = chunk_gated_delta_rule(qn, k, v, g, beta, chunk_size=4, output_final_state=False)
+        out, _ = chunk_gated_delta_rule(
+            qn,
+            k,
+            v,
+            g,
+            beta,
+            chunk_size=4,
+            output_final_state=False,
+            use_flash=use_flash,
+        )
         return jnp.sum(out.array)
 
     def loss_recur(q_arr):
         qn = hax.named(q_arr, q.axes)
-        out, _ = recurrent_gated_delta_rule(qn, k, v, g, beta, output_final_state=False)
+        out, _ = recurrent_gated_delta_rule(
+            qn,
+            k,
+            v,
+            g,
+            beta,
+            output_final_state=False,
+            use_flash=use_flash,
+        )
         return jnp.sum(out.array)
 
     g1 = jax.grad(loss_chunk)(q.array)
-    g2 = jax.grad(loss_recur)(q.array)
     assert jnp.all(jnp.isfinite(g1))
+
+    if use_flash:
+        return
+
+    g2 = jax.grad(loss_recur)(q.array)
     assert jnp.all(jnp.isfinite(g2))
 
 
@@ -283,7 +399,8 @@ def test_recurrent_kernel_matches_hf(use_flash: bool):
 
 
 @skip_if_no_torch
-def test_chunk_kernel_matches_hf():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_kernel_matches_hf(use_flash: bool):
     import torch
 
     hf_chunk, hf_recur = _get_hf_kernels()
@@ -292,7 +409,16 @@ def test_chunk_kernel_matches_hf():
     B, H, L, dk, dv = 2, 4, 64, 8, 16
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
-    out_named, _ = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=32, output_final_state=False)
+    out_named, _ = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=False,
+        use_flash=use_flash,
+    )
 
     def to_t(arr: jnp.ndarray):
         return torch.from_numpy(np.array(arr))
@@ -314,7 +440,8 @@ def test_chunk_kernel_matches_hf():
 
 
 @skip_if_no_torch
-def test_chunk_kernel_matches_hf_non_divisible():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_kernel_matches_hf_non_divisible(use_flash: bool):
     """L not divisible by chunk_size should still match HF fallback (padding path)."""
     import torch
 
@@ -326,7 +453,16 @@ def test_chunk_kernel_matches_hf_non_divisible():
 
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
-    out_named, _ = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=chunk_size, output_final_state=False)
+    out_named, _ = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        output_final_state=False,
+        use_flash=use_flash,
+    )
 
     def to_t(arr: jnp.ndarray):
         return torch.from_numpy(np.array(arr))
@@ -348,7 +484,8 @@ def test_chunk_kernel_matches_hf_non_divisible():
 
 
 @skip_if_no_torch
-def test_chunk_size_one_matches_hf_recurrent():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_size_one_matches_hf_recurrent(use_flash: bool):
     """chunk_size=1 should degenerate to the recurrent rule."""
     import torch
 
@@ -358,8 +495,25 @@ def test_chunk_size_one_matches_hf_recurrent():
     B, H, L, dk, dv = 2, 2, 29, 8, 8
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
-    out_chunk, _ = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=1, output_final_state=False)
-    out_recur, _ = recurrent_gated_delta_rule(q, k, v, g, beta, output_final_state=False)
+    out_chunk, _ = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=1,
+        output_final_state=False,
+        use_flash=use_flash,
+    )
+    out_recur, _ = recurrent_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output_final_state=False,
+        use_flash=use_flash,
+    )
     np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=1e-4, atol=1e-4)
 
     def to_t(arr: jnp.ndarray):
@@ -390,7 +544,8 @@ def test_chunk_size_one_matches_hf_recurrent():
 
 
 @skip_if_no_torch
-def test_chunk_kernel_with_initial_state_matches_recurrent_continuation():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_kernel_with_initial_state_matches_recurrent_continuation(use_flash: bool):
     """
     Provide an initial S0 and check chunk kernel == recurrent kernel on the same sequence.
     """
@@ -406,9 +561,26 @@ def test_chunk_kernel_with_initial_state_matches_recurrent_continuation():
     S0 = jax.random.normal(jax.random.PRNGKey(123), (B, H, dk, dv), dtype=jnp.float32) * 0.1
 
     out_chunk, _ = chunk_gated_delta_rule(
-        q, k, v, g, beta, chunk_size=chunk_size, initial_state=S0, output_final_state=False
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        initial_state=S0,
+        output_final_state=False,
+        use_flash=use_flash,
     )
-    out_recur, _ = recurrent_gated_delta_rule(q, k, v, g, beta, initial_state=S0, output_final_state=False)
+    out_recur, _ = recurrent_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=S0,
+        output_final_state=False,
+        use_flash=use_flash,
+    )
     np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=1e-4, atol=1e-4)
 
     def to_t(arr: jnp.ndarray):
@@ -440,7 +612,8 @@ def test_chunk_kernel_with_initial_state_matches_recurrent_continuation():
 
 
 @skip_if_no_torch
-def test_short_sequences_edge_cases():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_short_sequences_edge_cases(use_flash: bool):
     """Short L vs chunk_size and kernel-size behaviors."""
     import torch
 
@@ -452,7 +625,16 @@ def test_short_sequences_edge_cases():
         B, H, dk, dv = 2, 2, 8, 8
         q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
-        out_named, _ = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=64, output_final_state=False)
+        out_named, _ = chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            chunk_size=64,
+            output_final_state=False,
+            use_flash=use_flash,
+        )
 
         def to_t(arr: jnp.ndarray):
             return torch.from_numpy(np.array(arr))
@@ -473,7 +655,8 @@ def test_short_sequences_edge_cases():
 
 
 @skip_if_no_torch
-def test_extreme_gates_no_nans_and_parity():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_extreme_gates_no_nans_and_parity(use_flash: bool):
     """Stress alpha = exp(g) close to 0 (very negative g) and beta near 0/1."""
     import torch
 
@@ -488,7 +671,16 @@ def test_extreme_gates_no_nans_and_parity():
     beta_big = hax.named(jnp.full((B, L, H), 1.0 - 1e-6, dtype=jnp.float32), ("batch", "position", "heads"))
 
     for beta in [beta_small, beta_big]:
-        out_named, _ = chunk_gated_delta_rule(q, k, v, g, beta, chunk_size=32, output_final_state=False)
+        out_named, _ = chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            chunk_size=32,
+            output_final_state=False,
+            use_flash=use_flash,
+        )
 
         def to_t(arr: jnp.ndarray):
             return torch.from_numpy(np.array(arr))
@@ -509,7 +701,8 @@ def test_extreme_gates_no_nans_and_parity():
 
 
 @skip_if_no_torch
-def test_kernels_match_hf_without_l2norm():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_kernels_match_hf_without_l2norm(use_flash: bool):
     # TODO: fix edge case? although per original paper L2 norm is needed for stability
     pytest.skip("not matching HF implementation")
 
@@ -524,10 +717,25 @@ def test_kernels_match_hf_without_l2norm():
 
     # Haliax kernels with use_qk_l2norm_in_kernel=False
     out_chunk_j, _ = chunk_gated_delta_rule(
-        q, k, v, g, beta, chunk_size=32, output_final_state=False, use_qk_l2norm_in_kernel=False
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=False,
+        use_flash=use_flash,
     )
     out_recur_j, _ = recurrent_gated_delta_rule(
-        q, k, v, g, beta, output_final_state=False, use_qk_l2norm_in_kernel=False
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=False,
+        use_flash=use_flash,
     )
 
     # HF fallback expects (B, L, H, dim) on input and transposes internally; don't move axes.
@@ -639,7 +847,8 @@ def test_recurrent_backward_matches_hf():
 
 
 @skip_if_no_torch
-def test_chunk_backward_matches_hf():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_backward_matches_hf(use_flash: bool):
     """
     JAX vs HF fallback gradient parity for the chunkwise kernel (two chunks).
     Includes gradients w.r.t. q, k, v, g, beta, and initial_state S0.
@@ -673,6 +882,7 @@ def test_chunk_backward_matches_hf():
             initial_state=S0_arr,
             output_final_state=False,
             use_qk_l2norm_in_kernel=True,
+            use_flash=use_flash,
         )
         return jnp.sum(out.array)
 

--- a/tests/test_gdn_kernels.py
+++ b/tests/test_gdn_kernels.py
@@ -925,3 +925,308 @@ def test_chunk_backward_matches_hf(use_flash: bool):
     np.testing.assert_allclose(jg, tg, rtol=1e-4, atol=5e-6)
     np.testing.assert_allclose(jb, tb, rtol=1e-4, atol=5e-6)
     np.testing.assert_allclose(jS0, tS0, rtol=1e-4, atol=5e-6)
+
+
+# -------------------------------
+# Varlen / Flash-specific testing
+# -------------------------------
+
+
+@pytest.mark.parametrize("chunk_size", [1, 16, 32, 64])
+def test_chunk_varlen_lengths_matches_recurrent_prefix_and_state(chunk_size):
+    """Flash (varlen via lengths) == recurrent run up to each (b,h) length on the prefix."""
+    key = jax.random.PRNGKey(42)
+    B, H, L, dk, dv = 2, 3, 61, 8, 10  # dv=10 to exercise V-tiling/padding
+    q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
+
+    # Random ragged lengths in [0..L]; ensure we hit 0 and near-L
+    lengths_bh = jax.random.randint(key, (B, H), minval=0, maxval=L + 1)
+    lengths_bh = lengths_bh.at[0, 0].set(0).at[0, 1].set(L).astype(jnp.int32)
+
+    # Flash chunk with varlen lengths
+    out_chunk, S_chunk = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        initial_state=None,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        lengths=lengths_bh,
+    )
+    out_chunk_arr = np.array(out_chunk.array)
+    S_chunk_arr = np.array(S_chunk)
+
+    # Recurrent per sequence up to its length
+    out_ref = np.zeros((B, L, H, dv), dtype=np.float32)
+    S_ref = np.zeros((B, H, dk, dv), dtype=np.float32)
+    for b in range(B):
+        for h in range(H):
+            ell = int(lengths_bh[b, h])
+            if ell == 0:
+                # state zero and output zero (already initialized)
+                continue
+
+            # slice b,h,0:ell as NamedArrays (batch=1, heads=1)
+            q_i = q["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            k_i = k["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            v_i = v["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            g_i = g["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            b_i = beta["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+
+            out_i, S_i = recurrent_gated_delta_rule(
+                q_i,
+                k_i,
+                v_i,
+                g_i,
+                b_i,
+                initial_state=None,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                use_flash=False,  # use reference for parity
+            )
+            out_ref[b, :ell, h, :] = np.array(out_i.array)[0, :ell, 0, :]
+            S_ref[b, h, :, :] = np.array(S_i)[0, 0, :, :]
+
+    # Compare only the valid prefixes
+    for b in range(B):
+        for h in range(H):
+            ell = int(lengths_bh[b, h])
+            np.testing.assert_allclose(out_chunk_arr[b, :ell, h, :], out_ref[b, :ell, h, :], rtol=1e-4, atol=1e-4)
+            np.testing.assert_allclose(S_chunk_arr[b, h], S_ref[b, h], rtol=1e-4, atol=1e-4)
+
+    # All outputs should be finite
+    assert np.isfinite(out_chunk_arr).all()
+
+
+def test_chunk_varlen_offsets_equivalence():
+    """lengths and offsets (NH and NH+1) must yield identical outputs/states."""
+    key = jax.random.PRNGKey(123)
+    B, H, L, dk, dv = 2, 2, 47, 8, 8
+    q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
+
+    lengths_bh = jax.random.randint(key, (B, H), minval=0, maxval=L + 1).astype(jnp.int32)
+    lengths_flat = lengths_bh.reshape(-1)
+    offsets_plus1 = jnp.concatenate(
+        [jnp.array([0], dtype=jnp.int32), jnp.cumsum(lengths_flat, dtype=jnp.int32)], axis=0
+    )
+
+    # via lengths
+    out_len, S_len = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        lengths=lengths_bh,
+    )
+    # via offsets (NH+1)
+    out_off, S_off = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        offsets=offsets_plus1,
+    )
+    np.testing.assert_allclose(np.array(out_len.array), np.array(out_off.array), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(S_len, S_off, rtol=1e-5, atol=1e-5)
+
+    # via offsets (NH == lengths)
+    out_off2, S_off2 = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        offsets=lengths_flat,  # lengths form
+    )
+    np.testing.assert_allclose(np.array(out_len.array), np.array(out_off2.array), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(S_len, S_off2, rtol=1e-5, atol=1e-5)
+
+
+def test_chunk_varlen_zero_length_and_S0_unchanged():
+    """If a sequence has length 0, outputs are zero and S_final equals S0 for that (b,h)."""
+    key = jax.random.PRNGKey(7)
+    B, H, L, dk, dv = 2, 2, 33, 8, 8
+    q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
+
+    # Make one BH pair zero-length, others random
+    lengths_bh = jax.random.randint(key, (B, H), minval=1, maxval=L + 1).astype(jnp.int32)
+    lengths_bh = lengths_bh.at[0, 0].set(0)
+
+    # Random S0 to check "unchanged"
+    S0 = jax.random.normal(jax.random.PRNGKey(11), (B, H, dk, dv), dtype=jnp.float32)
+
+    out_chunk, S_fin = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=16,
+        initial_state=S0,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        lengths=lengths_bh,
+    )
+    out = np.array(out_chunk.array)
+    assert np.allclose(out[0, :, 0, :], 0.0, atol=1e-7)  # all positions are invalid => zeros
+    np.testing.assert_allclose(S_fin[0, 0], np.array(S0[0, 0]), rtol=1e-6, atol=1e-6)
+
+
+def test_chunk_varlen_head_first_layout_equivalence():
+    """head_first=True path should match the standard layout for the valid prefixes."""
+    key = jax.random.PRNGKey(99)
+    B, H, L, dk, dv = 1, 3, 57, 16, 10
+    q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
+
+    lengths_bh = jax.random.randint(key, (B, H), minval=0, maxval=L + 1).astype(jnp.int32)
+
+    # Standard path
+    out_std, _ = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=32,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        lengths=lengths_bh,
+        head_first=False,
+    )
+    out_std_arr = np.array(out_std.array)  # (B, L, H, V)
+
+    # Head-first inputs (B, H, L, *)
+    q_hf = hax.rearrange(q, ("batch", "heads", "position", "k_head_dim"))
+    k_hf = hax.rearrange(k, ("batch", "heads", "position", "k_head_dim"))
+    v_hf = hax.rearrange(v, ("batch", "heads", "position", "v_head_dim"))
+    g_hf = hax.rearrange(g, ("batch", "heads", "position"))
+    b_hf = hax.rearrange(beta, ("batch", "heads", "position"))
+
+    out_hf, _ = chunk_gated_delta_rule(
+        q_hf,
+        k_hf,
+        v_hf,
+        g_hf,
+        b_hf,
+        chunk_size=32,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        lengths=lengths_bh,
+        head_first=True,
+    )
+    # Bring back to (B, L, H, V)
+    out_hf_std = hax.rearrange(out_hf, ("batch", "position", "heads", "v_head_dim"))
+    out_hf_arr = np.array(out_hf_std.array)
+
+    # Compare only the valid prefixes for each head
+    for h in range(H):
+        ell = int(lengths_bh[0, h])
+        np.testing.assert_allclose(out_std_arr[0, :ell, h, :], out_hf_arr[0, :ell, h, :], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("chunk_size", [17, 32])
+def test_chunk_varlen_nondivisible_and_parity_with_recurrent(chunk_size):
+    """Non-divisible chunk sizes with varlen should match recurrent on valid prefixes."""
+    key = jax.random.PRNGKey(314)
+    B, H, L, dk, dv = 2, 2, 59, 8, 8
+    q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
+
+    lengths_bh = jax.random.randint(key, (B, H), minval=0, maxval=L + 1).astype(jnp.int32)
+
+    out_chunk, S_chunk = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        chunk_size=chunk_size,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_flash=True,
+        use_varlen=True,
+        lengths=lengths_bh,
+    )
+    out_chunk_arr = np.array(out_chunk.array)
+    S_chunk_arr = np.array(S_chunk)
+
+    # Reference recurrent per (b,h)
+    out_ref = np.zeros((B, L, H, dv), dtype=np.float32)
+    S_ref = np.zeros((B, H, dk, dv), dtype=np.float32)
+    for b in range(B):
+        for h in range(H):
+            ell = int(lengths_bh[b, h])
+            if ell == 0:
+                continue
+            q_i = q["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            k_i = k["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            v_i = v["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            g_i = g["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            b_i = beta["batch", hax.ds(b, Axis("b", 1))]["heads", hax.ds(h, Axis("h", 1))][
+                "position", hax.ds(0, Axis("p", ell))
+            ]
+            out_i, S_i = recurrent_gated_delta_rule(
+                q_i,
+                k_i,
+                v_i,
+                g_i,
+                b_i,
+                initial_state=None,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                use_flash=False,
+            )
+            out_ref[b, :ell, h, :] = np.array(out_i.array)[0, :ell, 0, :]
+            S_ref[b, h, :, :] = np.array(S_i)[0, 0, :, :]
+
+    # Compare only valid prefixes and final states
+    for b in range(B):
+        for h in range(H):
+            ell = int(lengths_bh[b, h])
+            np.testing.assert_allclose(out_chunk_arr[b, :ell, h, :], out_ref[b, :ell, h, :], rtol=1e-4, atol=1e-4)
+            np.testing.assert_allclose(S_chunk_arr[b, h, :, :], S_ref[b, h, :, :], rtol=1e-4, atol=1e-4)

--- a/tests/test_gdn_kernels.py
+++ b/tests/test_gdn_kernels.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import dataclasses
+
 import jax
 import jax.numpy as jnp
 import haliax as hax
+import haliax.nn as hnn
 from haliax import Axis
 import pytest
 
-from levanter.layers.gated_deltanet import chunk_gated_delta_rule, recurrent_gated_delta_rule
+from levanter.layers.gated_deltanet import FusedRMSNormGated, chunk_gated_delta_rule, recurrent_gated_delta_rule
 from tests.test_utils import skip_if_no_torch
 
 jax.config.update("jax_default_matmul_precision", "float32")
@@ -43,19 +46,49 @@ def _named_kernels_inputs(B, H, L, dk, dv, key):
     return q, k, v, g, beta
 
 
-def test_recurrent_no_learning_beta_zero_outputs_zero():
+def test_fused_rms_norm_gated_matches_reference():
+    key_x, key_g = jax.random.split(jax.random.PRNGKey(0))
+    Batch = Axis("batch", 2)
+    Pos = Axis("position", 3)
+    Hidden = Axis("hidden", 5)
+
+    module = FusedRMSNormGated.init(Hidden, eps=1e-6, use_flash=True)
+    module_ref = dataclasses.replace(module, use_flash=False)
+
+    x = hax.random.normal(key_x, (Batch, Pos, Hidden), dtype=jnp.float32)
+    gate = hax.random.normal(key_g, (Batch, Pos, Hidden), dtype=jnp.float32)
+
+    y_flash = module(x, gate)
+    y_ref = module_ref(x, gate)
+
+    x32 = x.astype(jnp.float32)
+    var = hax.mean(hax.square(x32), axis=Hidden)
+    inv = hax.rsqrt(var + jnp.asarray(module.eps, dtype=jnp.float32))
+    expected = (x32 * inv).astype(x.dtype)
+    expected = module.weight * expected
+    expected = expected * hnn.silu(gate)
+
+    np.testing.assert_allclose(y_flash.array, y_ref.array, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(y_flash.array, expected.array, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_recurrent_no_learning_beta_zero_outputs_zero(use_flash: bool):
     """If beta == 0 everywhere and S0 == 0, then S_t == 0 for all t and outputs are zero."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 2, 3, 17, 8, 8
     q, k, v, g, _ = _named_kernels_inputs(B, H, L, dk, dv, key)
     beta0 = hax.named(jnp.zeros((B, L, H), dtype=jnp.float32), ("batch", "position", "heads"))
 
-    out, S_final = recurrent_gated_delta_rule(q, k, v, g, beta0, initial_state=None, output_final_state=True)
+    out, S_final = recurrent_gated_delta_rule(
+        q, k, v, g, beta0, initial_state=None, output_final_state=True, use_flash=use_flash
+    )
     np.testing.assert_allclose(np.array(out.array), 0.0, rtol=1e-6, atol=1e-6)
     np.testing.assert_allclose(S_final, 0.0, rtol=1e-6, atol=1e-6)
 
 
-def test_recurrent_perfect_fit_on_current_key_when_alpha1_beta1_and_L2norm():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_recurrent_perfect_fit_on_current_key_when_alpha1_beta1_and_L2norm(use_flash: bool):
     """
     With α=1 (g=0) and β=1 and L2-normed K, the post-update state satisfies S_t^T k̂_t == v_t,
     where k̂_t is K L2-normalized along d_k (as in the kernel).
@@ -76,7 +109,15 @@ def test_recurrent_perfect_fit_on_current_key_when_alpha1_beta1_and_L2norm():
         b_t = beta1["position", hax.ds(t, Axis("one", 1))]
 
         _, S = recurrent_gated_delta_rule(
-            q_t, k_t, v_t, g_t, b_t, initial_state=S, output_final_state=True, use_qk_l2norm_in_kernel=True
+            q_t,
+            k_t,
+            v_t,
+            g_t,
+            b_t,
+            initial_state=S,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            use_flash=use_flash,
         )
 
         # Check S^T k̂_t == v_t (k̂_t is K normalized as in the kernel)
@@ -89,7 +130,8 @@ def test_recurrent_perfect_fit_on_current_key_when_alpha1_beta1_and_L2norm():
 
 
 @pytest.mark.parametrize("chunk_size", [1, 2, 7, 16, 32, 64])
-def test_chunk_equals_recurrent_for_random_inputs(chunk_size):
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_chunk_equals_recurrent_for_random_inputs(chunk_size, use_flash: bool):
     """Chunkwise kernel must match recurrent kernel for many chunk sizes (including 1)."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 2, 3, 57, 8, 8
@@ -164,7 +206,7 @@ def test_chunk_size_one_degenerates_to_recurrent_without_l2norm():
     out_recur, _ = recurrent_gated_delta_rule(
         q, k, v, g, beta, output_final_state=False, use_qk_l2norm_in_kernel=False
     )
-    np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(np.array(out_chunk.array), np.array(out_recur.array), rtol=3e-4, atol=1e-4)
 
 
 def test_extreme_gates_numerical_stability_jax_only():
@@ -210,7 +252,8 @@ def test_gradients_exist_small_kernel_graph():
 
 
 @skip_if_no_torch
-def test_recurrent_kernel_matches_hf():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_recurrent_kernel_matches_hf(use_flash: bool):
     import torch
 
     hf_chunk, hf_recur = _get_hf_kernels()
@@ -219,7 +262,7 @@ def test_recurrent_kernel_matches_hf():
     B, H, L, dk, dv = 1, 2, 17, 8, 8
     q, k, v, g, beta = _named_kernels_inputs(B, H, L, dk, dv, key)
 
-    out_named, _ = recurrent_gated_delta_rule(q, k, v, g, beta, output_final_state=False)
+    out_named, _ = recurrent_gated_delta_rule(q, k, v, g, beta, output_final_state=False, use_flash=use_flash)
 
     # HF expects (B, L, H, dim) on input and transposes internally.
     def to_t(arr: jnp.ndarray):
@@ -523,6 +566,7 @@ def test_recurrent_backward_matches_hf():
     """
     JAX vs HF fallback gradient parity for the recurrent (decode) kernel.
     We compare grads w.r.t. q, k, v, g, beta, and initial_state S0 on a small case.
+    Only test the fallback version, as this is not used for training anyways and only a sanity check.
     """
     import torch
 
@@ -551,6 +595,7 @@ def test_recurrent_backward_matches_hf():
             initial_state=S0_arr,
             output_final_state=False,
             use_qk_l2norm_in_kernel=True,
+            use_flash=False,
         )
         return jnp.sum(out.array)
 

--- a/tests/test_gdn_kernels.py
+++ b/tests/test_gdn_kernels.py
@@ -130,8 +130,7 @@ def test_recurrent_perfect_fit_on_current_key_when_alpha1_beta1_and_L2norm(use_f
 
 
 @pytest.mark.parametrize("chunk_size", [1, 2, 7, 16, 32, 64])
-@pytest.mark.parametrize("use_flash", [True, False])
-def test_chunk_equals_recurrent_for_random_inputs(chunk_size, use_flash: bool):
+def test_chunk_equals_recurrent_for_random_inputs(chunk_size):
     """Chunkwise kernel must match recurrent kernel for many chunk sizes (including 1)."""
     key = jax.random.PRNGKey(0)
     B, H, L, dk, dv = 2, 3, 57, 8, 8

--- a/tests/test_gdn_layer.py
+++ b/tests/test_gdn_layer.py
@@ -105,7 +105,8 @@ def _lev_state_from_hf_layer(lev_cfg: GatedDeltaNetConfig, hf_layer) -> dict[str
 # -------------------------------
 
 
-def test_layer_streaming_decode_matches_one_shot_prefill():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_layer_streaming_decode_matches_one_shot_prefill(use_flash: bool):
     """Streaming (per-token) with carried (conv_state, S_state) must match one-shot prefill."""
     key = jax.random.PRNGKey(0)
     B, L = 2, 20
@@ -118,7 +119,7 @@ def test_layer_streaming_decode_matches_one_shot_prefill():
         conv_kernel_size=4,
         rms_norm_eps=1e-6,
     )
-    layer = GatedDeltaNet.init(cfg, key=key)
+    layer = GatedDeltaNet.init(cfg, key=key, use_flash=use_flash)
 
     Batch, Pos, Embed = Axis("batch", B), Axis("position", L), cfg.Embed
     xkey = jax.random.PRNGKey(0)
@@ -137,14 +138,17 @@ def test_layer_streaming_decode_matches_one_shot_prefill():
     ys = []
     for t in range(L):
         xt = x["position", hax.ds(t, Axis("pos1", 1))]
-        y_t, (conv_state, S_state) = layer(xt, inference=True, chunk_size=8, decode_state=(conv_state, S_state))
+        y_t, state = layer(xt, inference=True, chunk_size=8, decode_state=(conv_state, S_state))
+        assert state is not None
+        conv_state, S_state = state
         ys.append(y_t.array)
 
     y_stream = np.concatenate(ys, axis=1)  # (B, L, Embed)
     np.testing.assert_allclose(y_stream, y_full.array, rtol=1e-5, atol=1e-5)
 
 
-def test_layer_masking_trailing_zeros_equivalence():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_layer_masking_trailing_zeros_equivalence(use_flash: bool):
     """Zeroing trailing positions via attention_mask should not change earlier outputs (causality)."""
     key = jax.random.PRNGKey(0)
     B, L = 2, 19
@@ -157,7 +161,7 @@ def test_layer_masking_trailing_zeros_equivalence():
         conv_kernel_size=4,
         rms_norm_eps=1e-6,
     )
-    layer = GatedDeltaNet.init(cfg, key=key)
+    layer = GatedDeltaNet.init(cfg, key=key, use_flash=use_flash)
 
     Batch, Pos, Embed = Axis("batch", B), Axis("position", L), cfg.Embed
     x = hax.named(jax.random.normal(key, (B, L, Embed.size), dtype=jnp.float32), (Batch, Pos, Embed))
@@ -176,7 +180,8 @@ def test_layer_masking_trailing_zeros_equivalence():
 
 
 @pytest.mark.parametrize("csize_a,csize_b", [(8, 16), (16, 32)])
-def test_layer_chunk_size_invariance(csize_a, csize_b):
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_layer_chunk_size_invariance(csize_a, csize_b, use_flash: bool):
     """Prefill outputs should be invariant to chunk size."""
     key = jax.random.PRNGKey(0)
     B, L = 2, 37
@@ -189,7 +194,7 @@ def test_layer_chunk_size_invariance(csize_a, csize_b):
         conv_kernel_size=4,
         rms_norm_eps=1e-6,
     )
-    layer = GatedDeltaNet.init(cfg, key=key)
+    layer = GatedDeltaNet.init(cfg, key=key, use_flash=use_flash)
 
     Batch, Pos, Embed = Axis("batch", B), Axis("position", L), cfg.Embed
     x = hax.named(jax.random.normal(key, (B, L, Embed.size), dtype=jnp.float32), (Batch, Pos, Embed))
@@ -199,7 +204,8 @@ def test_layer_chunk_size_invariance(csize_a, csize_b):
     np.testing.assert_allclose(y_a.array, y_b.array, rtol=1e-5, atol=1e-5)
 
 
-def test_layer_gradients_exist():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_layer_gradients_exist(use_flash: bool):
     """End-to-end differentiability: grads w.r.t. inputs exist and are finite."""
     key = jax.random.PRNGKey(0)
     B, L = 1, 12
@@ -212,7 +218,7 @@ def test_layer_gradients_exist():
         conv_kernel_size=4,
         rms_norm_eps=1e-6,
     )
-    layer = GatedDeltaNet.init(cfg, key=key)
+    layer = GatedDeltaNet.init(cfg, key=key, use_flash=use_flash)
 
     Batch, Pos, Embed = Axis("batch", B), Axis("position", L), cfg.Embed
     x0 = hax.named(jax.random.normal(key, (B, L, Embed.size), dtype=jnp.float32), (Batch, Pos, Embed))
@@ -227,7 +233,8 @@ def test_layer_gradients_exist():
 
 
 @skip_if_no_torch
-def test_gdn_layer_backward_matches_hf():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_gdn_layer_backward_matches_hf(use_flash: bool):
     import torch
 
     # Small configuration for a reasonably fast backward parity check
@@ -245,7 +252,7 @@ def test_gdn_layer_backward_matches_hf():
         rms_norm_eps=1e-6,
     )
     lev_state = _lev_state_from_hf_layer(lev_cfg, hf_layer)
-    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, key=jax.random.PRNGKey(0))
+    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, use_flash=use_flash, key=jax.random.PRNGKey(0))
 
     # Random input
     B, L = 1, 16
@@ -277,7 +284,8 @@ def test_gdn_layer_backward_matches_hf():
 
 
 @skip_if_no_torch
-def test_gdn_layer_matches_hf_prefill():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_gdn_layer_matches_hf_prefill(use_flash: bool):
     import torch  # local import for environments without torch
 
     def _to_torch(x):
@@ -288,7 +296,7 @@ def test_gdn_layer_matches_hf_prefill():
     lev_cfg, _ = _init_small_lev_layer(hidden_size, nk, nv, dk, dv, ksz)
 
     lev_state = _lev_state_from_hf_layer(lev_cfg, hf_layer)
-    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, key=jax.random.PRNGKey(0))
+    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, use_flash=use_flash, key=jax.random.PRNGKey(0))
 
     # random input
     B, L = 2, 64
@@ -335,7 +343,8 @@ def test_gdn_layer_matches_hf_prefill():
 
 
 @skip_if_no_torch
-def test_gdn_layer_decode_matches_hf_one_step():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_gdn_layer_decode_matches_hf_one_step(use_flash: bool):
     """
     Prefill to build state, then decode one token using the recurrent path in both Levanter and HF.
     Ensures conv-state length K and S-state handoff are correct and parity holds.
@@ -355,7 +364,7 @@ def test_gdn_layer_decode_matches_hf_one_step():
     )
 
     lev_state = _lev_state_from_hf_layer(lev_cfg, hf_layer)
-    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, key=jax.random.PRNGKey(0))
+    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, use_flash=use_flash, key=jax.random.PRNGKey(0))
 
     B, L = 2, 37
     x_full = jax.random.normal(jax.random.PRNGKey(1), (B, L, hidden_size), dtype=jnp.float32)
@@ -424,7 +433,73 @@ def test_depthwise_conv_update_equivalence():
 
 
 @skip_if_no_torch
-def test_ratio_equal_one_and_greater_than_one():
+def test_depthwise_conv_backward_matches_torch():
+    """Depthwise causal conv + SiLU: JAX vs Torch gradient parity wrt input and kernel."""
+    import torch
+    import torch.nn.functional as F
+
+    key = jax.random.PRNGKey(0)
+    N, C, L, K = 2, 5, 23, 7
+    x = jax.random.normal(key, (N, C, L), dtype=jnp.float32)
+    w = jax.random.normal(jax.random.PRNGKey(1), (C, K), dtype=jnp.float32)
+
+    def loss_jax(x_arr, w_arr):
+        y = _causal_depthwise_conv1d_full(x_arr, w_arr, None)
+        return jnp.sum(y)
+
+    gx_j, gw_j = jax.grad(loss_jax, argnums=(0, 1))(x, w)
+
+    # Torch reference: left-pad input by (K-1), depthwise conv (groups=C), no bias, SiLU
+    x_t = torch.from_numpy(np.array(x))
+    w_t = torch.from_numpy(np.array(w))
+    x_t.requires_grad_(True)
+    w_t.requires_grad_(True)
+    x_pad_t = F.pad(x_t, (K - 1, 0))  # left pad only
+    y_t = F.conv1d(x_pad_t, w_t[:, None, :], bias=None, stride=1, padding=0, groups=C)
+    y_t = F.silu(y_t)
+    loss_t = y_t.sum()
+    loss_t.backward()
+    gx_t = x_t.grad.detach().cpu().numpy()
+    gw_t = w_t.grad.detach().cpu().numpy()
+
+    np.testing.assert_allclose(np.array(gx_j), gx_t, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(np.array(gw_j), gw_t, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_layer_backward_chunk_size_invariance(use_flash: bool):
+    """Gradients wrt inputs should be invariant to chunk size choices in prefill/train path."""
+    key = jax.random.PRNGKey(0)
+    B, L = 1, 27
+    cfg = GatedDeltaNetConfig(
+        Embed=Axis("embed", 48),
+        num_k_heads=2,
+        num_v_heads=4,
+        head_k_dim=8,
+        head_v_dim=8,
+        conv_kernel_size=4,
+        rms_norm_eps=1e-6,
+    )
+    layer = GatedDeltaNet.init(cfg, key=key, use_flash=use_flash)
+
+    Batch, Pos, Embed = Axis("batch", B), Axis("position", L), cfg.Embed
+    x0 = hax.named(jax.random.normal(key, (B, L, Embed.size), dtype=jnp.float32), (Batch, Pos, Embed))
+
+    def loss_with_chunk(x_arr, chunk_size):
+        x = hax.named(x_arr, x0.axes)
+        y, _ = layer(x, inference=False, chunk_size=chunk_size)
+        return jnp.sum(y.array)
+
+    g8 = jax.grad(lambda arr: loss_with_chunk(arr, 8))(x0.array)
+    g32 = jax.grad(lambda arr: loss_with_chunk(arr, 32))(x0.array)
+
+    # fp32 accumulation order can cause tiny chunk-size dependent differences
+    np.testing.assert_allclose(np.array(g8), np.array(g32), rtol=3e-5, atol=3e-6)
+
+
+@skip_if_no_torch
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_ratio_equal_one_and_greater_than_one(use_flash: bool):
     """
     Exercise both ratio paths: nv == nk and nv > nk (repeat-interleave of Q/K).
     Run prefill parity vs HF in both cases.
@@ -444,7 +519,7 @@ def test_ratio_equal_one_and_greater_than_one():
         )
 
         lev_state = _lev_state_from_hf_layer(lev_cfg, hf_layer)
-        lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, key=jax.random.PRNGKey(0))
+        lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, use_flash=use_flash, key=jax.random.PRNGKey(0))
 
         B, L = 2, 64
         x_j = jax.random.normal(jax.random.PRNGKey(0), (B, L, hidden_size), dtype=jnp.float32)
@@ -462,7 +537,8 @@ def test_ratio_equal_one_and_greater_than_one():
 
 
 @skip_if_no_torch
-def test_linear_mask_zeroes_padded_tokens_prefill():
+@pytest.mark.parametrize("use_flash", [True, False])
+def test_linear_mask_zeroes_padded_tokens_prefill(use_flash: bool):
     hidden_size, nk, nv, dk, dv, ksz = 96, 4, 8, 8, 8, 4
     hf_cfg, hf_layer = _init_small_hf_layer_with_linear_only(hidden_size, nk, nv, dk, dv, ksz)
     lev_cfg = GatedDeltaNetConfig(
@@ -475,7 +551,7 @@ def test_linear_mask_zeroes_padded_tokens_prefill():
     )
 
     lev_state = _lev_state_from_hf_layer(lev_cfg, hf_layer)
-    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, key=jax.random.PRNGKey(0))
+    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, use_flash=use_flash, key=jax.random.PRNGKey(0))
 
     B, L_core, L_pad = 2, 16, 8
     x_core = jax.random.normal(jax.random.PRNGKey(0), (B, L_core, hidden_size), dtype=jnp.float32)

--- a/tests/test_gdn_layer.py
+++ b/tests/test_gdn_layer.py
@@ -227,6 +227,56 @@ def test_layer_gradients_exist():
 
 
 @skip_if_no_torch
+def test_gdn_layer_backward_matches_hf():
+    import torch
+
+    # Small configuration for a reasonably fast backward parity check
+    hidden_size, nk, nv, dk, dv, ksz = 96, 2, 2, 8, 8, 4
+    hf_cfg, hf_layer = _init_small_hf_layer(hidden_size, nk, nv, dk, dv, ksz)
+
+    # Initialize an equivalent Levanter layer from HF weights
+    lev_cfg = GatedDeltaNetConfig(
+        Embed=Axis("embed", hidden_size),
+        num_k_heads=nk,
+        num_v_heads=nv,
+        head_k_dim=dk,
+        head_v_dim=dv,
+        conv_kernel_size=ksz,
+        rms_norm_eps=1e-6,
+    )
+    lev_state = _lev_state_from_hf_layer(lev_cfg, hf_layer)
+    lev_layer = GatedDeltaNet.from_state_dict(lev_cfg, lev_state, key=jax.random.PRNGKey(0))
+
+    # Random input
+    B, L = 1, 16
+    x_j = jax.random.normal(jax.random.PRNGKey(0), (B, L, hidden_size), dtype=jnp.float32)
+    x_named = hax.named(x_j, (Axis("batch", B), Axis("position", L), Axis("embed", hidden_size)))
+
+    # JAX gradient wrt inputs
+    def loss_fn(x_arr):
+        x = hax.named(x_arr, x_named.axes)
+        y, _ = lev_layer(x, inference=False, chunk_size=8)
+        return jnp.sum(y.array)
+
+    g_jax = jax.grad(loss_fn)(x_named.array)
+
+    # HF (Torch) gradient wrt inputs
+    x_t = torch.from_numpy(np.array(x_j))
+    x_t.requires_grad_(True)
+    out_t = hf_layer(
+        hidden_states=x_t,
+        cache_params=None,
+        cache_position=None,
+        attention_mask=None,
+    )
+    loss_t = out_t.sum()
+    loss_t.backward()
+    g_torch = x_t.grad.detach().cpu().numpy()
+
+    np.testing.assert_allclose(np.array(g_jax), g_torch, rtol=1e-4, atol=1e-5)
+
+
+@skip_if_no_torch
 def test_gdn_layer_matches_hf_prefill():
     import torch  # local import for environments without torch
 


### PR DESCRIPTION
This draft PR adds "flash" implementations of recurrent and chunk gated delta rules, based on the Triton kernels from https://github.com/fla-org/flash-linear-attention. Notable improvements are:

- 2D tiling on `(num_heads, num_V_tiles)` grid, with K dim tiled internally in a loop
- fusing kernels, recomputing in backward, and other optimizations from the official FLA version
- support for varlen (ragged inputs)

Existing tests were parameterized with `@pytest.mark.parametrize("use_flash", [True, False])` and all pass on CPU `pl.pallas_call(..., interpret=True)`. Additional work is in progress to 1. make them work correctly on TPUs (https://docs.jax.dev/en/latest/pallas/tpu/index.html) and 2. refactor and cleanup, in particular move the flash code to a separate file.